### PR TITLE
Externalize DB connection settings

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -1,0 +1,17 @@
+using Exiled.API.Interfaces;
+using System.ComponentModel;
+
+namespace MaxunPlugin
+{
+    public class Config : IConfig
+    {
+        [Description("Whether the plugin is enabled.")]
+        public bool IsEnabled { get; set; } = true;
+
+        [Description("Enable debug messages.")]
+        public bool Debug { get; set; } = false;
+
+        [Description("Connection string for the MySQL database.")]
+        public string ConnectionString { get; set; } = "Server=localhost;Database=scp;User ID=maxundeli;Password=Maxx1826583ru;Pooling=true;";
+    }
+}

--- a/DB_Helper.cs
+++ b/DB_Helper.cs
@@ -6,14 +6,9 @@ public class MyDatabaseHelper
 {
     private readonly string connectionString;
 
-    public MyDatabaseHelper()
+    public MyDatabaseHelper(string connectionString)
     {
-        // Собери Connection String
-        connectionString = "Server=localhost;" +
-                           "Database=scp;" +
-                           "User ID=maxundeli;" +
-                           "Password=Maxx1826583ru;" +
-                           "Pooling=true;";
+        this.connectionString = connectionString;
     }
 
     public async Task TestConnectionAsync()

--- a/Main.cs
+++ b/Main.cs
@@ -109,7 +109,7 @@ public class Plugin : Plugin<Config>
 
     public override void OnEnabled()
     {
-        _dbHelper = new MyDatabaseHelper();
+        _dbHelper = new MyDatabaseHelper(Config.ConnectionString);
         Instance = this;
         Player.Died += OnDie;
         Player.Hurt += PlayerHurt;


### PR DESCRIPTION
## Summary
- add a `Config` class for plugin configuration
- inject connection string via `MyDatabaseHelper` constructor
- use the configured connection string in `Plugin.OnEnabled`

## Testing
- `dotnet build MaxunPlugin.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f47b579e48324b272e5de32d1886e