### PR TITLE
Implement flashlight chance

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -28,5 +28,8 @@ namespace MaxunPlugin
 
         [Description("Chance of blackout occurring per check (0-100).")]
         public int BlackoutChance { get; set; } = 33;
+
+        [Description("Chance of giving a flashlight to D-Class or Scientist players at round start (0-100).")]
+        public int FlashlightChance { get; set; } = 33;
     }
 }

--- a/Main.cs
+++ b/Main.cs
@@ -268,6 +268,13 @@ public class Plugin : Plugin<Config>
             int nonId = player.Id;
             Log.Warn(id + nickname + nonId);
             _dbHelper.CreateRow(id, nickname);
+
+            if ((player.Role == RoleTypeId.ClassD || player.Role == RoleTypeId.Scientist) &&
+                Random.Range(1, 101) <= Config.FlashlightChance)
+            {
+                player.AddItem(ItemType.Flashlight);
+            }
+
             if ((player.Role == RoleTypeId.Scp049 || player.Role == RoleTypeId.Scp0492 ||
                  player.Role == RoleTypeId.Scp079 || player.Role == RoleTypeId.Scp096 ||
                  player.Role == RoleTypeId.Scp106 || player.Role == RoleTypeId.Scp173 ||


### PR DESCRIPTION
## Summary
- add configuration option for giving flashlight
- give flashlight to D-Class and Scientist players with configurable chance at round start

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6856fce4ce048324aafec4472916942c