### PR TITLE
Add lobby stats hint

### DIFF
--- a/DB_Helper.cs
+++ b/DB_Helper.cs
@@ -84,4 +84,47 @@ public class MyDatabaseHelper
             throw;
         }
     }
+
+    public async Task<StoredPlayerStats?> GetStatsAsync(string id)
+    {
+        using var conn = new MySqlConnection(connectionString);
+        try
+        {
+            await conn.OpenAsync();
+            var cmd = new MySqlCommand(
+                "SELECT kills, damageDealed, timePlayed, FFkills, takedSCPObjects, SCPsKilled FROM scp_stat WHERE ID = @id;",
+                conn);
+            cmd.Parameters.AddWithValue("@id", id);
+            using var reader = await cmd.ExecuteReaderAsync();
+            if (await reader.ReadAsync())
+            {
+                return new StoredPlayerStats
+                {
+                    Kills = reader.GetInt32("kills"),
+                    DamageDealed = reader.GetInt32("damageDealed"),
+                    TimePlayed = reader["timePlayed"].ToString() ?? "0:00:00",
+                    FFkills = reader.GetInt32("FFkills"),
+                    TakedSCPObjects = reader.GetInt32("takedSCPObjects"),
+                    SCPsKilled = reader.GetInt32("SCPsKilled")
+                };
+            }
+        }
+        catch (Exception e)
+        {
+            Log.Error(e);
+            throw;
+        }
+
+        return null;
+    }
+}
+
+public class StoredPlayerStats
+{
+    public int Kills { get; set; }
+    public int DamageDealed { get; set; }
+    public string TimePlayed { get; set; } = string.Empty;
+    public int FFkills { get; set; }
+    public int TakedSCPObjects { get; set; }
+    public int SCPsKilled { get; set; }
 }

--- a/DB_Helper.cs
+++ b/DB_Helper.cs
@@ -1,7 +1,8 @@
-﻿using Exiled.API.Features;
+using Exiled.API.Features;
+using MySql.Data.MySqlClient;
+using System;
 
 namespace MaxunPlugin;
-using MySql.Data.MySqlClient;
 public class MyDatabaseHelper
 {
     private readonly string connectionString;
@@ -100,12 +101,12 @@ public class MyDatabaseHelper
             {
                 return new StoredPlayerStats
                 {
-                    Kills = reader.GetInt32("kills"),
-                    DamageDealed = reader.GetInt32("damageDealed"),
+                    Kills = Convert.ToInt32(reader["kills"]),
+                    DamageDealed = Convert.ToInt32(reader["damageDealed"]),
                     TimePlayed = reader["timePlayed"].ToString() ?? "0:00:00",
-                    FFkills = reader.GetInt32("FFkills"),
-                    TakedSCPObjects = reader.GetInt32("takedSCPObjects"),
-                    SCPsKilled = reader.GetInt32("SCPsKilled")
+                    FFkills = Convert.ToInt32(reader["FFkills"]),
+                    TakedSCPObjects = Convert.ToInt32(reader["takedSCPObjects"]),
+                    SCPsKilled = Convert.ToInt32(reader["SCPsKilled"])
                 };
             }
         }

--- a/Main.cs
+++ b/Main.cs
@@ -28,8 +28,9 @@ public class Plugin : Plugin<Config>
 
     public static Plugin Instance;
     private readonly Dictionary<string, PlayerLifeStats> _playerLifeStats = new();
-
     private readonly Dictionary<string, PlayerStats> _playerStats = new();
+    private readonly Dictionary<string, CoroutineHandle> _hintCoroutines = new();
+    private bool _roundStarted;
     private MyDatabaseHelper _dbHelper;
     private CoroutineHandle _DeadManCoroutine;
     private int _generatorCount;
@@ -62,8 +63,10 @@ public class Plugin : Plugin<Config>
         Player.Died += OnDie;
         Player.Hurt += PlayerHurt;
         Server.RespawnedTeam += OnTeamRespawned;
+        Server.WaitingForPlayers += OnWaitingForPlayers;
         Server.RoundStarted += OnRoundStarted;
         Player.Joined += OnJoined;
+        Player.Left += OnLeft;
         Server.RoundEnded += OnRoundEnd;
         Server.RestartingRound += OnRoundRestart;
         Scp096.AddingTarget += RageStart;
@@ -85,10 +88,12 @@ public class Plugin : Plugin<Config>
         Player.Hurt -= PlayerHurt;
         Server.RoundStarted -= OnRoundStarted;
         Player.Joined -= OnJoined;
+        Player.Left -= OnLeft;
         Exiled.Events.Handlers.Warhead.DeadmanSwitchInitiating -= DeadmanS;
         Server.RoundEnded -= OnRoundEnd;
         Server.RestartingRound -= OnRoundRestart;
         Server.RespawnedTeam -= OnTeamRespawned;
+        Server.WaitingForPlayers -= OnWaitingForPlayers;
         Scp096.AddingTarget -= RageStart;
         Player.Spawned -= PlayerSpawned;
         Exiled.Events.Handlers.Map.GeneratorActivating -= GeneratorAct;
@@ -212,10 +217,45 @@ public class Plugin : Plugin<Config>
         string playerIdSt = Convert.ToString(playerId);
         _playerStats[playerIdSt] = new PlayerStats { Kills = 0, DamageDealed = 0, FFkills = 0 };
         _playerLifeStats[playerIdSt] = new PlayerLifeStats { KillsLife = 0, DamageDealedLife = 0 };
+
+        if (Config.Database.Enabled)
+        {
+            _dbHelper.CreateRow(id, nickname);
+            if (!_roundStarted)
+                StartHintCoroutine(ev.Player);
+        }
+        else if (!_roundStarted)
+        {
+            StartHintCoroutine(ev.Player);
+        }
+    }
+
+    private void OnLeft(LeftEventArgs ev)
+    {
+        if (_hintCoroutines.TryGetValue(ev.Player.UserId, out var handle))
+        {
+            Timing.KillCoroutines(handle);
+            _hintCoroutines.Remove(ev.Player.UserId);
+        }
+    }
+
+    private void OnWaitingForPlayers()
+    {
+        _roundStarted = false;
+        foreach (var player in Exiled.API.Features.Player.List)
+        {
+            if (Config.Database.Enabled)
+                StartHintCoroutine(player);
+        }
     }
 
     private void OnRoundStarted()
     {
+        _roundStarted = true;
+        foreach (var handle in _hintCoroutines.Values)
+            Timing.KillCoroutines(handle);
+        _hintCoroutines.Clear();
+
         UnityEngine.Random.InitState((int)DateTime.UtcNow.Ticks);
         bool isScp3114Spawned = false;
         _warheadChanceCounter = 0;
@@ -289,6 +329,10 @@ public class Plugin : Plugin<Config>
 
     private void OnRoundEnd(RoundEndedEventArgs ev)
     {
+        foreach (var handle in _hintCoroutines.Values)
+            Timing.KillCoroutines(handle);
+        _hintCoroutines.Clear();
+
         ev.TimeToRestart = 15;
         Log.Info("Stopping coroutine");
         if (Config.Blackout.Enabled)
@@ -356,6 +400,10 @@ public class Plugin : Plugin<Config>
 
     private void OnRoundRestart()
     {
+        foreach (var handle in _hintCoroutines.Values)
+            Timing.KillCoroutines(handle);
+        _hintCoroutines.Clear();
+
         Log.Info("Stopping coroutine");
         if (Config.Blackout.Enabled)
         {
@@ -578,6 +626,35 @@ public class Plugin : Plugin<Config>
             }
 
             yield return Timing.WaitForSeconds(60f);
+        }
+    }
+
+    private void StartHintCoroutine(Exiled.API.Features.Player player)
+    {
+        if (_hintCoroutines.ContainsKey(player.UserId))
+            return;
+
+        var stats = _dbHelper.GetStatsAsync(player.UserId).GetAwaiter().GetResult();
+        if (stats == null)
+            return;
+
+        string hint = $"<b>Stats</b>\n" +
+                       $"Kills: <color=green>{stats.Kills}</color>\n" +
+                       $"Damage: <color=green>{stats.DamageDealed}</color>\n" +
+                       $"FF kills: <color=red>{stats.FFkills}</color>\n" +
+                       $"SCP kills: <color=green>{stats.SCPsKilled}</color>\n" +
+                       $"SCP items: <color=yellow>{stats.TakedSCPObjects}</color>\n" +
+                       $"Play time: <color=green>{stats.TimePlayed}</color>";
+
+        _hintCoroutines[player.UserId] = Timing.RunCoroutine(StatsHintCoroutine(player, hint));
+    }
+
+    private IEnumerator<float> StatsHintCoroutine(Exiled.API.Features.Player player, string text)
+    {
+        while (!_roundStarted && player.IsConnected)
+        {
+            player.ShowHint(text, 2f);
+            yield return Timing.WaitForSeconds(2f);
         }
     }
 

--- a/MaxunPlugin.csproj
+++ b/MaxunPlugin.csproj
@@ -34,7 +34,6 @@
   
 
   <ItemGroup>
-    <PackageReference Include="Exiled" Version="9.0.0-beta.5" />
     <PackageReference Include="MySql.Data" Version="9.2.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.Json" Version="9.0.4" />

--- a/MaxunPlugin.csproj
+++ b/MaxunPlugin.csproj
@@ -34,6 +34,7 @@
   
 
   <ItemGroup>
+    <PackageReference Include="Exiled" Version="9.0.0-beta.5" />
     <PackageReference Include="MySql.Data" Version="9.2.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.Json" Version="9.0.4" />


### PR DESCRIPTION
## Summary
- add method to fetch stored stats from DB
- show stats hints while waiting for players
- stop hints when the round begins or ends
- ensure DB rows exist for new players

## Testing
- `dotnet build -c Release` *(fails: missing Exiled dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68695287a20083249702133c6ba6ad4c

## Обзор от Sourcery

Добавлена функция подсказок статистики лобби путем получения сохраненной статистики игроков из базы данных и отображения ее в виде периодических подсказок во время ожидания игроков, обеспечения наличия записей в базе данных для новых игроков и очистки сопрограмм подсказок при старте, завершении раунда и выходе игрока.

Новые функции:
- Получение и отображение сохраненной статистики игроков в виде подсказок во время ожидания игроков.
- Создание строк базы данных для новых игроков при присоединении, если они отсутствуют.

Улучшения:
- Добавлен метод `GetStatsAsync` для получения статистики игроков из MySQL.
- Остановка и очистка сопрограмм подсказок статистики при старте раунда, завершении раунда и событиях выхода игрока.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add lobby stats hint feature by fetching stored player stats from the database and displaying them as periodic hints while waiting for players, ensure database entries for new players, and clean up hint coroutines on round start, end, and player leave.

New Features:
- Retrieve and show stored player stats as hints while waiting for players.
- Create database rows for new players upon joining if missing.

Enhancements:
- Add GetStatsAsync method to fetch player stats from MySQL.
- Stop and clear stat hint coroutines on round start, round end, and player leave events.

</details>