### PR TITLE
Add lobby stats hint

### DIFF
--- a/MaxunPlugin.csproj
+++ b/MaxunPlugin.csproj
@@ -34,6 +34,7 @@
   
 
   <ItemGroup>
+    <PackageReference Include="Exiled" Version="9.0.0-beta.5" />
     <PackageReference Include="MySql.Data" Version="9.2.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.Json" Version="9.0.4" />


### PR DESCRIPTION
## Summary
- add method to fetch stored stats from DB
- show stats hints while waiting for players
- stop hints when the round begins or ends
- ensure DB rows exist for new players
- convert DB fields safely when reading stats
- restore using the Exiled package for required assemblies
- fix lobby stats hint to avoid null user IDs

## Testing
- `dotnet build -c Release` *(fails: missing game assemblies)*

------
https://chatgpt.com/codex/tasks/task_e_68695287a20083249702133c6ba6ad4c