### PR TITLE
Add round start hint with total stats

### DIFF
--- a/DB_Helper.cs
+++ b/DB_Helper.cs
@@ -84,4 +84,44 @@ public class MyDatabaseHelper
             throw;
         }
     }
+
+    public async Task<DbPlayerStats> GetPlayerStatsAsync(string id)
+    {
+        using var conn = new MySqlConnection(connectionString);
+        var stats = new DbPlayerStats();
+        try
+        {
+            await conn.OpenAsync();
+            var cmd = new MySqlCommand(
+                "SELECT kills, damageDealed, timePlayed, FFkills, takedSCPObjects, SCPsKilled FROM scp_stat WHERE ID = @id;",
+                conn);
+            cmd.Parameters.AddWithValue("@id", id);
+            using var reader = await cmd.ExecuteReaderAsync();
+            if (await reader.ReadAsync())
+            {
+                stats.Kills = reader.GetInt32("kills");
+                stats.DamageDealed = reader.GetInt32("damageDealed");
+                stats.TimePlayed = reader.GetTimeSpan("timePlayed");
+                stats.FFkills = reader.GetInt32("FFkills");
+                stats.TakedSCPObjects = reader.GetInt32("takedSCPObjects");
+                stats.ScpsKilled = reader.GetInt32("SCPsKilled");
+            }
+        }
+        catch (Exception e)
+        {
+            Log.Error(e);
+        }
+
+        return stats;
+    }
+}
+
+public class DbPlayerStats
+{
+    public int Kills { get; set; }
+    public int DamageDealed { get; set; }
+    public TimeSpan TimePlayed { get; set; }
+    public int FFkills { get; set; }
+    public int TakedSCPObjects { get; set; }
+    public int ScpsKilled { get; set; }
 }

--- a/DB_Helper.cs
+++ b/DB_Helper.cs
@@ -96,15 +96,15 @@ public class MyDatabaseHelper
                 "SELECT kills, damageDealed, timePlayed, FFkills, takedSCPObjects, SCPsKilled FROM scp_stat WHERE ID = @id;",
                 conn);
             cmd.Parameters.AddWithValue("@id", id);
-            using var reader = await cmd.ExecuteReaderAsync();
+            using var reader = (MySqlDataReader)await cmd.ExecuteReaderAsync();
             if (await reader.ReadAsync())
             {
-                stats.Kills = reader.GetInt32("kills");
-                stats.DamageDealed = reader.GetInt32("damageDealed");
-                stats.TimePlayed = reader.GetTimeSpan("timePlayed");
-                stats.FFkills = reader.GetInt32("FFkills");
-                stats.TakedSCPObjects = reader.GetInt32("takedSCPObjects");
-                stats.ScpsKilled = reader.GetInt32("SCPsKilled");
+                stats.Kills = reader.GetInt32(0);
+                stats.DamageDealed = reader.GetInt32(1);
+                stats.TimePlayed = reader.GetTimeSpan(2);
+                stats.FFkills = reader.GetInt32(3);
+                stats.TakedSCPObjects = reader.GetInt32(4);
+                stats.ScpsKilled = reader.GetInt32(5);
             }
         }
         catch (Exception e)

--- a/Main.cs
+++ b/Main.cs
@@ -385,13 +385,14 @@ public class Plugin : Plugin<Config>
         var scpKillsRank = await _dbHelper.GetStatRankAsync(id, "SCPsKilled");
         var scpItemsRank = await _dbHelper.GetStatRankAsync(id, "takedSCPObjects");
 
-        string hint = "<size=22><b><color=#ffb84d>Statistics</color></b></size>\n" +
-                     "<size=20>Kills: <color=red>" + dbStats.Kills + "</color>" + FormatRank(killsRank) +
-                     "  Damage: <color=red>" + dbStats.DamageDealed + "</color>" + FormatRank(damageRank) + "</size>\n" +
-                     "<size=20>FF kills: <color=red>" + dbStats.FFkills + "</color>" + FormatRank(ffRank) +
-                     "  SCP kills: <color=red>" + dbStats.ScpsKilled + "</color>" + FormatRank(scpKillsRank) + "</size>\n" +
-                     "<size=20>SCP items: <color=red>" + dbStats.TakedSCPObjects + "</color>" + FormatRank(scpItemsRank) +
-                     "  Playtime: <color=green>" + dbStats.TimePlayed.ToString("hh':'mm':'ss") + "</color></size>";
+        string hint =
+            "<size=22><b><color=#ffb84d>Statistics</color></b></size>\n" +
+            "<size=20>Kills: <color=red>"     + dbStats.Kills            + "</color>" + FormatRank(killsRank)      + "</size>\n" +
+            "<size=20>Damage: <color=red>"    + dbStats.DamageDealed     + "</color>" + FormatRank(damageRank)     + "</size>\n" +
+            "<size=20>FF kills: <color=red>"  + dbStats.FFkills          + "</color>" + FormatRank(ffRank)         + "</size>\n" +
+            "<size=20>SCP kills: <color=red>" + dbStats.ScpsKilled       + "</color>" + FormatRank(scpKillsRank)   + "</size>\n" +
+            "<size=20>SCP items: <color=red>" + dbStats.TakedSCPObjects  + "</color>" + FormatRank(scpItemsRank)   + "</size>\n" +
+            "<size=20>Playtime: <color=green>" + dbStats.TimePlayed.ToString("hh':'mm':'ss") + "</color></size>";
 
         player.ShowHint(hint, 7f);
     }

--- a/Main.cs
+++ b/Main.cs
@@ -378,10 +378,10 @@ public class Plugin : Plugin<Config>
     {
         await Task.Delay(TimeSpan.FromSeconds(15));
         var dbStats = await _dbHelper.GetPlayerStatsAsync(id);
-        string hint = "<b><color=#ffb84d>Statistics</color></b>\n" +
-                     "Kills: <color=red>" + dbStats.Kills + "</color>  Damage: <color=red>" + dbStats.DamageDealed + "</color>\n" +
-                     "FF kills: <color=red>" + dbStats.FFkills + "</color>  SCP kills: <color=red>" + dbStats.ScpsKilled + "</color>\n" +
-                     "SCP items: <color=red>" + dbStats.TakedSCPObjects + "</color>  Playtime: <color=green>" + dbStats.TimePlayed.ToString("hh':'mm':'ss") + "</color>";
+        string hint = "<size=22><b><color=#ffb84d>Statistics</color></b></size>\n" +
+                     "<size=20>Kills: <color=red>" + dbStats.Kills + "</color>  Damage: <color=red>" + dbStats.DamageDealed + "</color></size>\n" +
+                     "<size=20>FF kills: <color=red>" + dbStats.FFkills + "</color>  SCP kills: <color=red>" + dbStats.ScpsKilled + "</color></size>\n" +
+                     "<size=20>SCP items: <color=red>" + dbStats.TakedSCPObjects + "</color>  Playtime: <color=green>" + dbStats.TimePlayed.ToString("hh':'mm':'ss") + "</color></size>";
         player.ShowHint(hint, 7f);
     }
 

--- a/Main.cs
+++ b/Main.cs
@@ -253,10 +253,10 @@ public class Plugin : Plugin<Config>
             if (Config.Stats.Enabled && Config.Database.Enabled)
             {
                 var dbStats = _dbHelper.GetPlayerStatsAsync(id).GetAwaiter().GetResult();
-                string hint = $"<b><color=#ffb84d>Statistics</color></b>\n" +
-                              $"Kills: <color=red>{dbStats.Kills}</color>  Damage: <color=red>{dbStats.DamageDealed}</color>\n" +
-                              $"FF kills: <color=red>{dbStats.FFkills}</color>  SCP kills: <color=red>{dbStats.ScpsKilled}</color>\n" +
-                              $"SCP items: <color=red>{dbStats.TakedSCPObjects}</color>  Playtime: <color=green>{dbStats.TimePlayed:hh\\:mm\\:ss}</color>";
+                string hint = "<b><color=#ffb84d>Statistics</color></b>\n" +
+                             "Kills: <color=red>" + dbStats.Kills + "</color>  Damage: <color=red>" + dbStats.DamageDealed + "</color>\n" +
+                             "FF kills: <color=red>" + dbStats.FFkills + "</color>  SCP kills: <color=red>" + dbStats.ScpsKilled + "</color>\n" +
+                             "SCP items: <color=red>" + dbStats.TakedSCPObjects + "</color>  Playtime: <color=green>" + dbStats.TimePlayed.ToString("hh':'mm':'ss") + "</color>";
                 player.ShowHint(hint, 7f);
             }
 

--- a/Main.cs
+++ b/Main.cs
@@ -14,6 +14,7 @@ using MySql.Data.MySqlClient;
 using PlayerRoles;
 using UnityEngine;
 using Cassie = Exiled.API.Features.Cassie;
+using System.Threading.Tasks;
 // библиотека корутин
 using Map = Exiled.API.Features.Map;
 using Player = Exiled.Events.Handlers.Player;
@@ -214,7 +215,7 @@ public class Plugin : Plugin<Config>
         _playerLifeStats[playerIdSt] = new PlayerLifeStats { KillsLife = 0, DamageDealedLife = 0 };
     }
 
-    private void OnRoundStarted()
+    private async void OnRoundStarted()
     {
         UnityEngine.Random.InitState((int)DateTime.UtcNow.Ticks);
         bool isScp3114Spawned = false;
@@ -252,12 +253,7 @@ public class Plugin : Plugin<Config>
 
             if (Config.Stats.Enabled && Config.Database.Enabled)
             {
-                var dbStats = _dbHelper.GetPlayerStatsAsync(id).GetAwaiter().GetResult();
-                string hint = "<b><color=#ffb84d>Statistics</color></b>\n" +
-                             "Kills: <color=red>" + dbStats.Kills + "</color>  Damage: <color=red>" + dbStats.DamageDealed + "</color>\n" +
-                             "FF kills: <color=red>" + dbStats.FFkills + "</color>  SCP kills: <color=red>" + dbStats.ScpsKilled + "</color>\n" +
-                             "SCP items: <color=red>" + dbStats.TakedSCPObjects + "</color>  Playtime: <color=green>" + dbStats.TimePlayed.ToString("hh':'mm':'ss") + "</color>";
-                player.ShowHint(hint, 7f);
+                _ = ShowPlayerStatsAsync(player, id);
             }
 
             if (Config.SpawnItems.TryGetValue(player.Role, out var spawnList))
@@ -376,6 +372,16 @@ public class Plugin : Plugin<Config>
 
         if (Config.AutoBomb.Enabled)
             Timing.KillCoroutines(_warheadCoroutine);
+    }
+
+    private async Task ShowPlayerStatsAsync(Exiled.API.Features.Player player, string id)
+    {
+        var dbStats = await _dbHelper.GetPlayerStatsAsync(id);
+        string hint = "<b><color=#ffb84d>Statistics</color></b>\n" +
+                     "Kills: <color=red>" + dbStats.Kills + "</color>  Damage: <color=red>" + dbStats.DamageDealed + "</color>\n" +
+                     "FF kills: <color=red>" + dbStats.FFkills + "</color>  SCP kills: <color=red>" + dbStats.ScpsKilled + "</color>\n" +
+                     "SCP items: <color=red>" + dbStats.TakedSCPObjects + "</color>  Playtime: <color=green>" + dbStats.TimePlayed.ToString("hh':'mm':'ss") + "</color>";
+        player.ShowHint(hint, 7f);
     }
 
 

--- a/Main.cs
+++ b/Main.cs
@@ -250,6 +250,16 @@ public class Plugin : Plugin<Config>
             if (Config.Database.Enabled)
                 _dbHelper.CreateRow(id, nickname);
 
+            if (Config.Stats.Enabled && Config.Database.Enabled)
+            {
+                var dbStats = _dbHelper.GetPlayerStatsAsync(id).GetAwaiter().GetResult();
+                string hint = $"<b><color=#ffb84d>Statistics</color></b>\n" +
+                              $"Kills: <color=red>{dbStats.Kills}</color>  Damage: <color=red>{dbStats.DamageDealed}</color>\n" +
+                              $"FF kills: <color=red>{dbStats.FFkills}</color>  SCP kills: <color=red>{dbStats.ScpsKilled}</color>\n" +
+                              $"SCP items: <color=red>{dbStats.TakedSCPObjects}</color>  Playtime: <color=green>{dbStats.TimePlayed:hh\\:mm\\:ss}</color>";
+                player.ShowHint(hint, 7f);
+            }
+
             if (Config.SpawnItems.TryGetValue(player.Role, out var spawnList))
             {
                 foreach (var spawn in spawnList)

--- a/Main.cs
+++ b/Main.cs
@@ -376,6 +376,7 @@ public class Plugin : Plugin<Config>
 
     private async Task ShowPlayerStatsAsync(Exiled.API.Features.Player player, string id)
     {
+        await Task.Delay(TimeSpan.FromSeconds(15));
         var dbStats = await _dbHelper.GetPlayerStatsAsync(id);
         string hint = "<b><color=#ffb84d>Statistics</color></b>\n" +
                      "Kills: <color=red>" + dbStats.Kills + "</color>  Damage: <color=red>" + dbStats.DamageDealed + "</color>\n" +


### PR DESCRIPTION
## Summary
- query database for total player statistics
- show global player stats in a hint when the round starts

## Testing
- `dotnet build -c Release` *(fails: missing game/EXILED dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686a9088e6708324a032c99bf8c0a98c

## Обзор от Sourcery

Извлечение совокупной статистики игрока из базы данных и отображение ее в виде форматированной подсказки игроку при начале нового раунда.

Новые возможности:
- Добавлены модель `DbPlayerStats` и метод `GetPlayerStatsAsync` для получения общей статистики игрока из базы данных.
- Отображение подсказки в начале раунда, показывающей глобальную статистику игрока (убийства, урон, убийства союзников, убийства SCP, предметы SCP и время игры), когда включены статистика и база данных.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Retrieve cumulative player statistics from the database and display them as a formatted hint to the player when a new round starts.

New Features:
- Add DbPlayerStats model and GetPlayerStatsAsync method to fetch total player statistics from the database.
- Display a round-start hint showing global player stats (kills, damage, FF kills, SCP kills, SCP items, and playtime) when stats and database are enabled.

</details>