### PR TITLE
Implement ranking display for player stats

### DIFF
--- a/DB_Helper.cs
+++ b/DB_Helper.cs
@@ -114,6 +114,35 @@ public class MyDatabaseHelper
 
         return stats;
     }
+
+    public async Task<int?> GetStatRankAsync(string id, string column)
+    {
+        using var conn = new MySqlConnection(connectionString);
+        try
+        {
+            await conn.OpenAsync();
+
+            var getValueCmd = new MySqlCommand($"SELECT `{column}` FROM scp_stat WHERE ID = @id;", conn);
+            getValueCmd.Parameters.AddWithValue("@id", id);
+            object? valueObj = await getValueCmd.ExecuteScalarAsync();
+
+            if (valueObj == null || valueObj == DBNull.Value)
+                return null;
+
+            int value = Convert.ToInt32(valueObj);
+
+            var rankCmd = new MySqlCommand($"SELECT COUNT(*) + 1 FROM scp_stat WHERE `{column}` > @value;", conn);
+            rankCmd.Parameters.AddWithValue("@value", value);
+            object? rankObj = await rankCmd.ExecuteScalarAsync();
+
+            return Convert.ToInt32(rankObj);
+        }
+        catch (Exception e)
+        {
+            Log.Error(e);
+            return null;
+        }
+    }
 }
 
 public class DbPlayerStats

--- a/Main.cs
+++ b/Main.cs
@@ -377,12 +377,39 @@ public class Plugin : Plugin<Config>
     private async Task ShowPlayerStatsAsync(Exiled.API.Features.Player player, string id)
     {
         await Task.Delay(TimeSpan.FromSeconds(15));
+
         var dbStats = await _dbHelper.GetPlayerStatsAsync(id);
+        var killsRank = await _dbHelper.GetStatRankAsync(id, "kills");
+        var damageRank = await _dbHelper.GetStatRankAsync(id, "damageDealed");
+        var ffRank = await _dbHelper.GetStatRankAsync(id, "FFkills");
+        var scpKillsRank = await _dbHelper.GetStatRankAsync(id, "SCPsKilled");
+        var scpItemsRank = await _dbHelper.GetStatRankAsync(id, "takedSCPObjects");
+
         string hint = "<size=22><b><color=#ffb84d>Statistics</color></b></size>\n" +
-                     "<size=20>Kills: <color=red>" + dbStats.Kills + "</color>  Damage: <color=red>" + dbStats.DamageDealed + "</color></size>\n" +
-                     "<size=20>FF kills: <color=red>" + dbStats.FFkills + "</color>  SCP kills: <color=red>" + dbStats.ScpsKilled + "</color></size>\n" +
-                     "<size=20>SCP items: <color=red>" + dbStats.TakedSCPObjects + "</color>  Playtime: <color=green>" + dbStats.TimePlayed.ToString("hh':'mm':'ss") + "</color></size>";
+                     "<size=20>Kills: <color=red>" + dbStats.Kills + "</color>" + FormatRank(killsRank) +
+                     "  Damage: <color=red>" + dbStats.DamageDealed + "</color>" + FormatRank(damageRank) + "</size>\n" +
+                     "<size=20>FF kills: <color=red>" + dbStats.FFkills + "</color>" + FormatRank(ffRank) +
+                     "  SCP kills: <color=red>" + dbStats.ScpsKilled + "</color>" + FormatRank(scpKillsRank) + "</size>\n" +
+                     "<size=20>SCP items: <color=red>" + dbStats.TakedSCPObjects + "</color>" + FormatRank(scpItemsRank) +
+                     "  Playtime: <color=green>" + dbStats.TimePlayed.ToString("hh':'mm':'ss") + "</color></size>";
+
         player.ShowHint(hint, 7f);
+    }
+
+    private static string FormatRank(int? rank)
+    {
+        if (!rank.HasValue || rank.Value > 3)
+            return string.Empty;
+
+        string color = rank.Value switch
+        {
+            1 => "#FFD700",
+            2 => "#C0C0C0",
+            3 => "#CD7F32",
+            _ => "white"
+        };
+
+        return $" <color={color}>★{rank.Value}★</color>";
     }
 
 


### PR DESCRIPTION
## Summary
- show player's ranking for every stat in the round start hint
- color ranks gold, silver or bronze depending on position
- query database to compute rank for each statistic

## Testing
- `dotnet build -c Release` *(fails: missing EXILED references)*

------
https://chatgpt.com/codex/tasks/task_e_686a9fe81acc83248fd5c96bf7975d19

## Обзор от Sourcery

Отображение рейтингов статистики игроков в начале раунда путем запроса базы данных для каждой статистики и цветовой кодировки трех лучших позиций во всплывающей подсказке.

Новые функции:
- Отображение рейтинга каждого игрока по убийствам, урону, убийствам союзников, убийствам SCP и предметам SCP во всплывающей подсказке в начале раунда.
- Цветовая кодировка трех лучших рангов золотым, серебряным и бронзовым цветами.

Улучшения:
- Добавлен метод `GetStatRankAsync` в `DB_Helper` для вычисления рейтинга игрока по заданной статистике.
- Реализован метод `FormatRank` для добавления цветных звезд ранга к отображению статистики.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Display player stat rankings at round start by querying the database for each statistic and color-coding the top three positions in the on-screen hint.

New Features:
- Show each player's ranking for kills, damage, FF kills, SCP kills, and SCP items in the round-start hint
- Color-code top three ranks in gold, silver, and bronze

Enhancements:
- Add GetStatRankAsync in DB_Helper to compute a player's rank for a given statistic
- Implement FormatRank method to append colored rank stars to the stats display

</details>