### PR TITLE
Add stats command

### DIFF
--- a/Commands/StatsCommand.cs
+++ b/Commands/StatsCommand.cs
@@ -1,0 +1,35 @@
+using System;
+using CommandSystem;
+using Exiled.API.Features;
+
+namespace MaxunPlugin.Commands
+{
+    [CommandHandler(typeof(GameConsoleCommandHandler))]
+    public class StatsCommand : ICommand
+    {
+        public string Command => "stats";
+        public string[] Aliases => Array.Empty<string>();
+        public string Description => "Show your statistics.";
+
+        public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
+        {
+            Player player = Player.Get(sender);
+            if (player is null)
+            {
+                response = "This command can only be used in-game.";
+                return false;
+            }
+
+            var plugin = Plugin.Instance;
+            if (!plugin.Config.Stats.Enabled || !plugin.Config.Database.Enabled)
+            {
+                response = "Statistics are disabled.";
+                return false;
+            }
+
+            _ = plugin.ShowPlayerStatsAsync(player, player.UserId);
+            response = "Statistics hint shown.";
+            return true;
+        }
+    }
+}

--- a/Main.cs
+++ b/Main.cs
@@ -253,7 +253,7 @@ public class Plugin : Plugin<Config>
 
             if (Config.Stats.Enabled && Config.Database.Enabled)
             {
-                _ = ShowPlayerStatsAsync(player, id);
+                _ = ShowPlayerStatsAsync(player, id, true);
             }
 
             if (Config.SpawnItems.TryGetValue(player.Role, out var spawnList))
@@ -374,9 +374,10 @@ public class Plugin : Plugin<Config>
             Timing.KillCoroutines(_warheadCoroutine);
     }
 
-    private async Task ShowPlayerStatsAsync(Exiled.API.Features.Player player, string id)
+    public async Task ShowPlayerStatsAsync(Exiled.API.Features.Player player, string id, bool withDelay = false)
     {
-        await Task.Delay(TimeSpan.FromSeconds(15));
+        if (withDelay)
+            await Task.Delay(TimeSpan.FromSeconds(15));
 
         var dbStats = await _dbHelper.GetPlayerStatsAsync(id);
         var killsRank = await _dbHelper.GetStatRankAsync(id, "kills");


### PR DESCRIPTION
## Summary
- make stats display method accessible
- add new `stats` game console command

## Testing
- `dotnet build -c Release` *(fails: CS0246 type or namespace not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa18a1a4c8324b8696cd64500488f

## Обзор от Sourcery

Добавление новой консольной команды для отображения статистики игрока и рефакторинг метода отображения статистики для поддержки опциональной начальной задержки.

Новые возможности:
- Добавлена консольная команда `stats` для отображения статистики игрока в игре.

Улучшения:
- Метод `ShowPlayerStatsAsync` сделан публичным, добавлен опциональный параметр `withDelay` для управления начальной задержкой перед получением статистики.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new console command to display player statistics and refactor the stats display method to support optional initial delay.

New Features:
- Introduce a `stats` game console command that shows a player’s stats in-game.

Enhancements:
- Make `ShowPlayerStatsAsync` public, add an optional `withDelay` parameter to control the initial delay before fetching stats.

</details>