### PR TITLE
Rewrite stat tracking

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -98,6 +98,14 @@ namespace MaxunPlugin
         
     public class StatsModule : ModuleBase
     {
+        [Description("Broadcast template when a player kills too many allies. {killer} - attacker, {victim} - victim, {count} - kill count")]
+        public string TeamkillMessage { get; set; } = "<color=blue>{killer}</color> <color=white>killed {victim}. Teamkills: <color=red>{count}</color>";
+
+        [Description("Enable broadcast on excessive teamkills.")]
+        public bool TeamkillBroadcast { get; set; } = true;
+
+        [Description("Teamkill threshold for broadcast.")]
+        public int TeamkillLimit { get; set; } = 3;
     }
 
     public class AutoBombModule : ModuleBase

--- a/Config.cs
+++ b/Config.cs
@@ -75,6 +75,12 @@ namespace MaxunPlugin
         [Description("Connection string for the MySQL database.")]
         public string ConnectionString { get; set; } =
             "Server=localhost;Database=scp_db;User ID=scp_user;Password=scp_password;Pooling=true;";
+
+        [Description("Table name for human player statistics.")]
+        public string HumanTable { get; set; } = "human_stats";
+
+        [Description("Table name for SCP statistics.")]
+        public string ScpTable { get; set; } = "scp_stats";
     }
 
     public class BlackoutModule : ModuleBase

--- a/DB_Helper.cs
+++ b/DB_Helper.cs
@@ -201,6 +201,24 @@ public class HumanDbStats
     public int DamageToScp;
     public TimeSpan TimePlayed;
     public TimeSpan TimeAlive;
+
+    public HumanDbStats() { }
+
+    public HumanDbStats(Plugin.RoleStats r)
+    {
+        Damage = r.Damage;
+        Kills = r.Kills;
+        Deaths = r.Deaths;
+        DeathsFromScp = r.DeathsFromScp;
+        DeathsFromHuman = r.DeathsFromHuman;
+        ScpItems = r.ScpItems;
+        ScpsKilled = r.ScpsKilled;
+        FFKills = r.FFKills;
+        Escapes = r.Escapes;
+        DamageToScp = r.DamageToScp;
+        TimePlayed = r.TimePlayed;
+        TimeAlive = r.TimeAlive;
+    }
 }
 
 public class ScpDbStats
@@ -213,4 +231,18 @@ public class ScpDbStats
     public int DamageToScp;
     public TimeSpan TimePlayed;
     public TimeSpan TimeAlive;
+
+    public ScpDbStats() { }
+
+    public ScpDbStats(Plugin.RoleStats r)
+    {
+        Damage = r.Damage;
+        Kills = r.Kills;
+        Deaths = r.Deaths;
+        DeathsFromScp = r.DeathsFromScp;
+        DeathsFromHuman = r.DeathsFromHuman;
+        DamageToScp = r.DamageToScp;
+        TimePlayed = r.TimePlayed;
+        TimeAlive = r.TimeAlive;
+    }
 }

--- a/DB_Helper.cs
+++ b/DB_Helper.cs
@@ -1,156 +1,216 @@
-﻿using Exiled.API.Features;
+using Exiled.API.Features;
+using MySql.Data.MySqlClient;
 
 namespace MaxunPlugin;
-using MySql.Data.MySqlClient;
+
 public class MyDatabaseHelper
 {
-    private readonly string connectionString;
+    private readonly string _connectionString;
 
     public MyDatabaseHelper(string connectionString)
     {
-        this.connectionString = connectionString;
+        _connectionString = connectionString;
     }
 
     public async Task TestConnectionAsync()
     {
-        using (var conn = new MySqlConnection(connectionString))
-        {
-            await conn.OpenAsync();
-            // Выполняем запрос для получения версии MySQL
-            var cmd = new MySqlCommand("SELECT VERSION();", conn);
-            object? result = await cmd.ExecuteScalarAsync();
-            string version = result?.ToString();
-            Log.Info("MySQL version: " + version);
-        }
+        using var conn = new MySqlConnection(_connectionString);
+        await conn.OpenAsync();
+        var cmd = new MySqlCommand("SELECT VERSION();", conn);
+        object? result = await cmd.ExecuteScalarAsync();
+        Log.Info("MySQL version: " + result);
     }
 
     public async Task CreateRow(string id, string nickname)
     {
-        using (var conn = new MySqlConnection(connectionString))
-        {
-            try
-            {
-                await conn.OpenAsync();
-                var cmd = new MySqlCommand(
-                    "INSERT IGNORE INTO `scp_stat` (`ID`, `nickname`, `kills`, `damageDealed`, `timePlayed`, `FFkills`, `takedSCPObjects`, `SCPsKilled`) " +
-                    "VALUES (@id, @nickname, 0, 0, '00:00:00', 0, 0, 0);",
-                    conn
-                );
-                cmd.Parameters.AddWithValue("@id", id);
-                cmd.Parameters.AddWithValue("@nickname", nickname);
-                await cmd.ExecuteNonQueryAsync();
-            }
-            catch (Exception e)
-            {
-                Log.Error(e);
-                throw;
-            }
-        }
+        using var conn = new MySqlConnection(_connectionString);
+        await conn.OpenAsync();
+        var cmdHuman = new MySqlCommand(
+            "INSERT IGNORE INTO human_stats (ID,nickname,damage,kills,deaths,deaths_scp,deaths_human,scp_items,scps_killed,ff_kills,escapes,damage_to_scp,time_played,time_alive) " +
+            "VALUES (@id,@n,0,0,0,0,0,0,0,0,0,0,'00:00:00','00:00:00');",
+            conn);
+        cmdHuman.Parameters.AddWithValue("@id", id);
+        cmdHuman.Parameters.AddWithValue("@n", nickname);
+        await cmdHuman.ExecuteNonQueryAsync();
+
+        var cmdScp = new MySqlCommand(
+            "INSERT IGNORE INTO scp_stats (ID,nickname,damage,kills,deaths,deaths_scp,deaths_human,damage_to_scp,time_played,time_alive) " +
+            "VALUES (@id,@n,0,0,0,0,0,0,'00:00:00','00:00:00');",
+            conn);
+        cmdScp.Parameters.AddWithValue("@id", id);
+        cmdScp.Parameters.AddWithValue("@n", nickname);
+        await cmdScp.ExecuteNonQueryAsync();
     }
 
-    public async Task UpdateStat(string id, int kills, int damageDealed, TimeSpan timeplayed, int FFkillsCount,
-        int takedSCPObjects, int SCPsKilled)
+    public async Task UpdateNickname(string id, string nickname)
     {
-        using var conn = new MySqlConnection(connectionString);
-        try
-        {
-            await conn.OpenAsync();
-
-            var cmd = new MySqlCommand(
-                @"UPDATE scp_stat
-                  SET kills = kills + @kills,
-                      damageDealed = damageDealed + @damageDealed,
-                      timePlayed = ADDTIME(timePlayed, @timePlayed),
-                      FFkills = FFkills + @FFkillsCount,
-                      takedSCPObjects = takedSCPObjects + @takedSCPObjects,
-                      SCPsKilled = SCPsKilled + @SCPsKilled
-                  WHERE ID = @userId;",
-                conn
-            );
-
-            cmd.Parameters.AddWithValue("@kills", kills);
-            cmd.Parameters.AddWithValue("@damageDealed", damageDealed);
-            cmd.Parameters.AddWithValue("@timePlayed", timeplayed);
-            cmd.Parameters.AddWithValue("@FFkillsCount", FFkillsCount);
-            cmd.Parameters.AddWithValue("@takedSCPObjects", takedSCPObjects);
-            cmd.Parameters.AddWithValue("@SCPsKilled", SCPsKilled);
-            cmd.Parameters.AddWithValue("@userId", id);
-
-            await cmd.ExecuteNonQueryAsync();
-        }
-        catch (Exception e)
-        {
-            Log.Error(e);
-            throw;
-        }
+        using var conn = new MySqlConnection(_connectionString);
+        await conn.OpenAsync();
+        var cmd = new MySqlCommand(
+            "UPDATE human_stats SET nickname=@n WHERE ID=@id; UPDATE scp_stats SET nickname=@n WHERE ID=@id;",
+            conn);
+        cmd.Parameters.AddWithValue("@id", id);
+        cmd.Parameters.AddWithValue("@n", nickname);
+        await cmd.ExecuteNonQueryAsync();
     }
 
-    public async Task<DbPlayerStats> GetPlayerStatsAsync(string id)
+    public async Task UpdateHumanStats(string id, HumanDbStats s)
     {
-        using var conn = new MySqlConnection(connectionString);
-        var stats = new DbPlayerStats();
-        try
-        {
-            await conn.OpenAsync();
-            var cmd = new MySqlCommand(
-                "SELECT kills, damageDealed, timePlayed, FFkills, takedSCPObjects, SCPsKilled FROM scp_stat WHERE ID = @id;",
-                conn);
-            cmd.Parameters.AddWithValue("@id", id);
-            using var reader = (MySqlDataReader)await cmd.ExecuteReaderAsync();
-            if (await reader.ReadAsync())
-            {
-                stats.Kills = reader.GetInt32(0);
-                stats.DamageDealed = reader.GetInt32(1);
-                stats.TimePlayed = reader.GetTimeSpan(2);
-                stats.FFkills = reader.GetInt32(3);
-                stats.TakedSCPObjects = reader.GetInt32(4);
-                stats.ScpsKilled = reader.GetInt32(5);
-            }
-        }
-        catch (Exception e)
-        {
-            Log.Error(e);
-        }
+        using var conn = new MySqlConnection(_connectionString);
+        await conn.OpenAsync();
+        var cmd = new MySqlCommand(
+            @"UPDATE human_stats
+              SET damage = damage + @dmg,
+                  kills = kills + @k,
+                  deaths = deaths + @de,
+                  deaths_scp = deaths_scp + @dscp,
+                  deaths_human = deaths_human + @dhum,
+                  scp_items = scp_items + @scpitems,
+                  scps_killed = scps_killed + @scpk,
+                  ff_kills = ff_kills + @ff,
+                  escapes = escapes + @esc,
+                  damage_to_scp = damage_to_scp + @dmgscp,
+                  time_played = ADDTIME(time_played,@tp),
+                  time_alive = ADDTIME(time_alive,@ta)
+              WHERE ID=@id;",
+            conn);
+        cmd.Parameters.AddWithValue("@dmg", s.Damage);
+        cmd.Parameters.AddWithValue("@k", s.Kills);
+        cmd.Parameters.AddWithValue("@de", s.Deaths);
+        cmd.Parameters.AddWithValue("@dscp", s.DeathsFromScp);
+        cmd.Parameters.AddWithValue("@dhum", s.DeathsFromHuman);
+        cmd.Parameters.AddWithValue("@scpitems", s.ScpItems);
+        cmd.Parameters.AddWithValue("@scpk", s.ScpsKilled);
+        cmd.Parameters.AddWithValue("@ff", s.FFKills);
+        cmd.Parameters.AddWithValue("@esc", s.Escapes);
+        cmd.Parameters.AddWithValue("@dmgscp", s.DamageToScp);
+        cmd.Parameters.AddWithValue("@tp", s.TimePlayed);
+        cmd.Parameters.AddWithValue("@ta", s.TimeAlive);
+        cmd.Parameters.AddWithValue("@id", id);
+        await cmd.ExecuteNonQueryAsync();
+    }
 
+    public async Task UpdateScpStats(string id, ScpDbStats s)
+    {
+        using var conn = new MySqlConnection(_connectionString);
+        await conn.OpenAsync();
+        var cmd = new MySqlCommand(
+            @"UPDATE scp_stats
+              SET damage = damage + @dmg,
+                  kills = kills + @k,
+                  deaths = deaths + @de,
+                  deaths_scp = deaths_scp + @dscp,
+                  deaths_human = deaths_human + @dhum,
+                  damage_to_scp = damage_to_scp + @dmgscp,
+                  time_played = ADDTIME(time_played,@tp),
+                  time_alive = ADDTIME(time_alive,@ta)
+              WHERE ID=@id;",
+            conn);
+        cmd.Parameters.AddWithValue("@dmg", s.Damage);
+        cmd.Parameters.AddWithValue("@k", s.Kills);
+        cmd.Parameters.AddWithValue("@de", s.Deaths);
+        cmd.Parameters.AddWithValue("@dscp", s.DeathsFromScp);
+        cmd.Parameters.AddWithValue("@dhum", s.DeathsFromHuman);
+        cmd.Parameters.AddWithValue("@dmgscp", s.DamageToScp);
+        cmd.Parameters.AddWithValue("@tp", s.TimePlayed);
+        cmd.Parameters.AddWithValue("@ta", s.TimeAlive);
+        cmd.Parameters.AddWithValue("@id", id);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    public async Task<HumanDbStats> GetHumanStatsAsync(string id)
+    {
+        using var conn = new MySqlConnection(_connectionString);
+        var stats = new HumanDbStats();
+        await conn.OpenAsync();
+        var cmd = new MySqlCommand(
+            "SELECT damage,kills,deaths,deaths_scp,deaths_human,scp_items,scps_killed,ff_kills,escapes,damage_to_scp,time_played,time_alive FROM human_stats WHERE ID=@id;",
+            conn);
+        cmd.Parameters.AddWithValue("@id", id);
+        using var reader = (MySqlDataReader)await cmd.ExecuteReaderAsync();
+        if (await reader.ReadAsync())
+        {
+            stats.Damage = reader.GetInt32(0);
+            stats.Kills = reader.GetInt32(1);
+            stats.Deaths = reader.GetInt32(2);
+            stats.DeathsFromScp = reader.GetInt32(3);
+            stats.DeathsFromHuman = reader.GetInt32(4);
+            stats.ScpItems = reader.GetInt32(5);
+            stats.ScpsKilled = reader.GetInt32(6);
+            stats.FFKills = reader.GetInt32(7);
+            stats.Escapes = reader.GetInt32(8);
+            stats.DamageToScp = reader.GetInt32(9);
+            stats.TimePlayed = reader.GetTimeSpan(10);
+            stats.TimeAlive = reader.GetTimeSpan(11);
+        }
         return stats;
     }
 
-    public async Task<int?> GetStatRankAsync(string id, string column)
+    public async Task<ScpDbStats> GetScpStatsAsync(string id)
     {
-        using var conn = new MySqlConnection(connectionString);
-        try
+        using var conn = new MySqlConnection(_connectionString);
+        var stats = new ScpDbStats();
+        await conn.OpenAsync();
+        var cmd = new MySqlCommand(
+            "SELECT damage,kills,deaths,deaths_scp,deaths_human,damage_to_scp,time_played,time_alive FROM scp_stats WHERE ID=@id;",
+            conn);
+        cmd.Parameters.AddWithValue("@id", id);
+        using var reader = (MySqlDataReader)await cmd.ExecuteReaderAsync();
+        if (await reader.ReadAsync())
         {
-            await conn.OpenAsync();
-
-            var getValueCmd = new MySqlCommand($"SELECT `{column}` FROM scp_stat WHERE ID = @id;", conn);
-            getValueCmd.Parameters.AddWithValue("@id", id);
-            object? valueObj = await getValueCmd.ExecuteScalarAsync();
-
-            if (valueObj == null || valueObj == DBNull.Value)
-                return null;
-
-            int value = Convert.ToInt32(valueObj);
-
-            var rankCmd = new MySqlCommand($"SELECT COUNT(*) + 1 FROM scp_stat WHERE `{column}` > @value;", conn);
-            rankCmd.Parameters.AddWithValue("@value", value);
-            object? rankObj = await rankCmd.ExecuteScalarAsync();
-
-            return Convert.ToInt32(rankObj);
+            stats.Damage = reader.GetInt32(0);
+            stats.Kills = reader.GetInt32(1);
+            stats.Deaths = reader.GetInt32(2);
+            stats.DeathsFromScp = reader.GetInt32(3);
+            stats.DeathsFromHuman = reader.GetInt32(4);
+            stats.DamageToScp = reader.GetInt32(5);
+            stats.TimePlayed = reader.GetTimeSpan(6);
+            stats.TimeAlive = reader.GetTimeSpan(7);
         }
-        catch (Exception e)
-        {
-            Log.Error(e);
+        return stats;
+    }
+
+    public async Task<int?> GetStatRankAsync(string id, string column, string table)
+    {
+        using var conn = new MySqlConnection(_connectionString);
+        await conn.OpenAsync();
+        var valCmd = new MySqlCommand($"SELECT `{column}` FROM {table} WHERE ID=@id;", conn);
+        valCmd.Parameters.AddWithValue("@id", id);
+        object? obj = await valCmd.ExecuteScalarAsync();
+        if (obj == null || obj == DBNull.Value)
             return null;
-        }
+        int value = Convert.ToInt32(obj);
+        var rankCmd = new MySqlCommand($"SELECT COUNT(*) + 1 FROM {table} WHERE `{column}` > @v;", conn);
+        rankCmd.Parameters.AddWithValue("@v", value);
+        object? rankObj = await rankCmd.ExecuteScalarAsync();
+        return Convert.ToInt32(rankObj);
     }
 }
 
-public class DbPlayerStats
+public class HumanDbStats
 {
-    public int Kills { get; set; }
-    public int DamageDealed { get; set; }
-    public TimeSpan TimePlayed { get; set; }
-    public int FFkills { get; set; }
-    public int TakedSCPObjects { get; set; }
-    public int ScpsKilled { get; set; }
+    public int Damage;
+    public int Kills;
+    public int Deaths;
+    public int DeathsFromScp;
+    public int DeathsFromHuman;
+    public int ScpItems;
+    public int ScpsKilled;
+    public int FFKills;
+    public int Escapes;
+    public int DamageToScp;
+    public TimeSpan TimePlayed;
+    public TimeSpan TimeAlive;
+}
+
+public class ScpDbStats
+{
+    public int Damage;
+    public int Kills;
+    public int Deaths;
+    public int DeathsFromScp;
+    public int DeathsFromHuman;
+    public int DamageToScp;
+    public TimeSpan TimePlayed;
+    public TimeSpan TimeAlive;
 }

--- a/DB_Helper.cs
+++ b/DB_Helper.cs
@@ -293,7 +293,7 @@ public class HumanDbStats
 
     public HumanDbStats(Plugin.RoleStats r)
     {
-        Damage = r.Damage;
+        Damage = (int)Math.Round(r.Damage);
         Kills = r.Kills;
         Deaths = r.Deaths;
         DeathsFromScp = r.DeathsFromScp;
@@ -302,7 +302,7 @@ public class HumanDbStats
         ScpsKilled = r.ScpsKilled;
         FFKills = r.FFKills;
         Escapes = r.Escapes;
-        DamageToScp = r.DamageToScp;
+        DamageToScp = (int)Math.Round(r.DamageToScp);
         TimePlayed = r.TimePlayed;
         TimeAlive = r.TimeAlive;
         DamagePerTen = 0;
@@ -330,12 +330,12 @@ public class ScpDbStats
 
     public ScpDbStats(Plugin.RoleStats r)
     {
-        Damage = r.Damage;
+        Damage = (int)Math.Round(r.Damage);
         Kills = r.Kills;
         Deaths = r.Deaths;
         DeathsFromScp = r.DeathsFromScp;
         DeathsFromHuman = r.DeathsFromHuman;
-        DamageToScp = r.DamageToScp;
+        DamageToScp = (int)Math.Round(r.DamageToScp);
         TimePlayed = r.TimePlayed;
         TimeAlive = r.TimeAlive;
         DamagePerTen = 0;

--- a/DB_Helper.cs
+++ b/DB_Helper.cs
@@ -1,15 +1,35 @@
 using Exiled.API.Features;
 using MySql.Data.MySqlClient;
+using System;
+using System.Threading.Tasks;
 
 namespace MaxunPlugin;
 
 public class MyDatabaseHelper
 {
     private readonly string _connectionString;
+    private readonly string _humanTable;
+    private readonly string _scpTable;
 
-    public MyDatabaseHelper(string connectionString)
+    public MyDatabaseHelper(string connectionString, string humanTable, string scpTable)
     {
         _connectionString = connectionString;
+        _humanTable = humanTable;
+        _scpTable = scpTable;
+    }
+
+    public async Task InitializeAsync()
+    {
+        try
+        {
+            await TestConnectionAsync();
+            await EnsureTablesAsync();
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Database initialization failed: {ex.Message}");
+            Log.Debug(ex.StackTrace);
+        }
     }
 
     public async Task TestConnectionAsync()
@@ -21,12 +41,61 @@ public class MyDatabaseHelper
         Log.Info("MySQL version: " + result);
     }
 
+    public async Task EnsureTablesAsync()
+    {
+        Log.Info("Opening database connection...");
+        using var conn = new MySqlConnection(_connectionString);
+        await conn.OpenAsync();
+        Log.Info("Connection opened. Ensuring tables...");
+
+        var humanCmd = new MySqlCommand($@"CREATE TABLE IF NOT EXISTS `{_humanTable}` (
+            ID VARCHAR(64) NOT NULL PRIMARY KEY,
+            nickname VARCHAR(32) NOT NULL,
+            damage INT NOT NULL DEFAULT 0,
+                kills INT NOT NULL DEFAULT 0,
+                deaths INT NOT NULL DEFAULT 0,
+                deaths_scp INT NOT NULL DEFAULT 0,
+                deaths_human INT NOT NULL DEFAULT 0,
+                scp_items INT NOT NULL DEFAULT 0,
+                scps_killed INT NOT NULL DEFAULT 0,
+                ff_kills INT NOT NULL DEFAULT 0,
+                escapes INT NOT NULL DEFAULT 0,
+                damage_to_scp INT NOT NULL DEFAULT 0,
+                time_played TIME NOT NULL DEFAULT '00:00:00',
+                time_alive TIME NOT NULL DEFAULT '00:00:00',
+                damage_10m DOUBLE NOT NULL DEFAULT 0,
+                kills_10m DOUBLE NOT NULL DEFAULT 0,
+                ff_kills_10m DOUBLE NOT NULL DEFAULT 0,
+                deaths_10m DOUBLE NOT NULL DEFAULT 0
+            );", conn);
+        await humanCmd.ExecuteNonQueryAsync();
+        Log.Info($"Ensured table '{_humanTable}'");
+
+        var scpCmd = new MySqlCommand($@"CREATE TABLE IF NOT EXISTS `{_scpTable}` (
+            ID VARCHAR(64) NOT NULL PRIMARY KEY,
+            nickname VARCHAR(32) NOT NULL,
+            damage INT NOT NULL DEFAULT 0,
+                kills INT NOT NULL DEFAULT 0,
+                deaths INT NOT NULL DEFAULT 0,
+                deaths_scp INT NOT NULL DEFAULT 0,
+                deaths_human INT NOT NULL DEFAULT 0,
+                damage_to_scp INT NOT NULL DEFAULT 0,
+                time_played TIME NOT NULL DEFAULT '00:00:00',
+                time_alive TIME NOT NULL DEFAULT '00:00:00',
+                damage_10m DOUBLE NOT NULL DEFAULT 0,
+                kills_10m DOUBLE NOT NULL DEFAULT 0,
+                deaths_10m DOUBLE NOT NULL DEFAULT 0
+            );", conn);
+        await scpCmd.ExecuteNonQueryAsync();
+        Log.Info($"Ensured table '{_scpTable}'");
+    }
+
     public async Task CreateRow(string id, string nickname)
     {
         using var conn = new MySqlConnection(_connectionString);
         await conn.OpenAsync();
         var cmdHuman = new MySqlCommand(
-            "INSERT IGNORE INTO human_stats (ID,nickname,damage,kills,deaths,deaths_scp,deaths_human,scp_items,scps_killed,ff_kills,escapes,damage_to_scp,time_played,time_alive,damage_10m,kills_10m,ff_kills_10m,deaths_10m) " +
+            $"INSERT IGNORE INTO `{_humanTable}` (ID,nickname,damage,kills,deaths,deaths_scp,deaths_human,scp_items,scps_killed,ff_kills,escapes,damage_to_scp,time_played,time_alive,damage_10m,kills_10m,ff_kills_10m,deaths_10m) " +
             "VALUES (@id,@n,0,0,0,0,0,0,0,0,0,0,'00:00:00','00:00:00',0,0,0,0);",
             conn);
         cmdHuman.Parameters.AddWithValue("@id", id);
@@ -34,7 +103,7 @@ public class MyDatabaseHelper
         await cmdHuman.ExecuteNonQueryAsync();
 
         var cmdScp = new MySqlCommand(
-            "INSERT IGNORE INTO scp_stats (ID,nickname,damage,kills,deaths,deaths_scp,deaths_human,damage_to_scp,time_played,time_alive,damage_10m,kills_10m,deaths_10m) " +
+            $"INSERT IGNORE INTO `{_scpTable}` (ID,nickname,damage,kills,deaths,deaths_scp,deaths_human,damage_to_scp,time_played,time_alive,damage_10m,kills_10m,deaths_10m) " +
             "VALUES (@id,@n,0,0,0,0,0,0,'00:00:00','00:00:00',0,0,0);",
             conn);
         cmdScp.Parameters.AddWithValue("@id", id);
@@ -47,7 +116,7 @@ public class MyDatabaseHelper
         using var conn = new MySqlConnection(_connectionString);
         await conn.OpenAsync();
         var cmd = new MySqlCommand(
-            "UPDATE human_stats SET nickname=@n WHERE ID=@id; UPDATE scp_stats SET nickname=@n WHERE ID=@id;",
+            $"UPDATE `{_humanTable}` SET nickname=@n WHERE ID=@id; UPDATE `{_scpTable}` SET nickname=@n WHERE ID=@id;",
             conn);
         cmd.Parameters.AddWithValue("@id", id);
         cmd.Parameters.AddWithValue("@n", nickname);
@@ -59,7 +128,7 @@ public class MyDatabaseHelper
         using var conn = new MySqlConnection(_connectionString);
         await conn.OpenAsync();
         var cmd = new MySqlCommand(
-            @"UPDATE human_stats
+            @$"UPDATE `{_humanTable}`
               SET damage = damage + @dmg,
                   kills = kills + @k,
                   deaths = deaths + @de,
@@ -99,7 +168,7 @@ public class MyDatabaseHelper
         using var conn = new MySqlConnection(_connectionString);
         await conn.OpenAsync();
         var cmd = new MySqlCommand(
-            @"UPDATE scp_stats
+            @$"UPDATE `{_scpTable}`
               SET damage = damage + @dmg,
                   kills = kills + @k,
                   deaths = deaths + @de,
@@ -131,7 +200,7 @@ public class MyDatabaseHelper
         var stats = new HumanDbStats();
         await conn.OpenAsync();
         var cmd = new MySqlCommand(
-            "SELECT damage,kills,deaths,deaths_scp,deaths_human,scp_items,scps_killed,ff_kills,escapes,damage_to_scp,time_played,time_alive,damage_10m,kills_10m,ff_kills_10m,deaths_10m FROM human_stats WHERE ID=@id;",
+            $"SELECT damage,kills,deaths,deaths_scp,deaths_human,scp_items,scps_killed,ff_kills,escapes,damage_to_scp,time_played,time_alive,damage_10m,kills_10m,ff_kills_10m,deaths_10m FROM `{_humanTable}` WHERE ID=@id;",
             conn);
         cmd.Parameters.AddWithValue("@id", id);
         using var reader = (MySqlDataReader)await cmd.ExecuteReaderAsync();
@@ -163,7 +232,7 @@ public class MyDatabaseHelper
         var stats = new ScpDbStats();
         await conn.OpenAsync();
         var cmd = new MySqlCommand(
-            "SELECT damage,kills,deaths,deaths_scp,deaths_human,damage_to_scp,time_played,time_alive,damage_10m,kills_10m,deaths_10m FROM scp_stats WHERE ID=@id;",
+            $"SELECT damage,kills,deaths,deaths_scp,deaths_human,damage_to_scp,time_played,time_alive,damage_10m,kills_10m,deaths_10m FROM `{_scpTable}` WHERE ID=@id;",
             conn);
         cmd.Parameters.AddWithValue("@id", id);
         using var reader = (MySqlDataReader)await cmd.ExecuteReaderAsync();

--- a/Main.cs
+++ b/Main.cs
@@ -154,7 +154,20 @@ public class Plugin : Plugin<Config>
                 if (ev.Attacker != ev.Player)
                     att.Kills++;
 
-                bool allyKill = ev.Attacker.Role.Team == ev.Player.Role.Team && ev.Attacker.Role.Side != Side.Scp;
+                bool allyKill =
+                    (ev.Attacker.Role.Side == Side.ChaosInsurgency &&
+                     (ev.Player.PreviousRole == RoleTypeId.ChaosConscript ||
+                      ev.Player.PreviousRole == RoleTypeId.ChaosMarauder ||
+                      ev.Player.PreviousRole == RoleTypeId.ChaosRepressor ||
+                      ev.Player.PreviousRole == RoleTypeId.ChaosRifleman ||
+                      ev.Player.PreviousRole == RoleTypeId.ClassD)) ||
+                    (ev.Attacker.Role.Side == Side.Mtf &&
+                     (ev.Player.PreviousRole == RoleTypeId.NtfCaptain ||
+                      ev.Player.PreviousRole == RoleTypeId.NtfPrivate ||
+                      ev.Player.PreviousRole == RoleTypeId.NtfSergeant ||
+                      ev.Player.PreviousRole == RoleTypeId.NtfSpecialist ||
+                      ev.Player.PreviousRole == RoleTypeId.Scientist ||
+                      ev.Player.PreviousRole == RoleTypeId.FacilityGuard));
 
                 if (!aStats.CurrentIsScp)
                 {

--- a/Main.cs
+++ b/Main.cs
@@ -387,6 +387,9 @@ public class Plugin : Plugin<Config>
             var dmg10Rank = await _dbHelper.GetStatRankAsync(id, "damage_10m", Config.Database.HumanTable);
             var ff10Rank = await _dbHelper.GetStatRankAsync(id, "ff_kills_10m", Config.Database.HumanTable);
             var deaths10Rank = await _dbHelper.GetStatRankAsync(id, "deaths_10m", Config.Database.HumanTable);
+            var scpItemsRank = await _dbHelper.GetStatRankAsync(id, "scp_items", Config.Database.HumanTable);
+            var scpsKilledRank = await _dbHelper.GetStatRankAsync(id, "scps_killed", Config.Database.HumanTable);
+            var escapesRank = await _dbHelper.GetStatRankAsync(id, "escapes", Config.Database.HumanTable);
 
             string hint =
                 "<size=22><b><color=#ffb84d>Statistics</color></b></size>\n" +
@@ -394,8 +397,10 @@ public class Plugin : Plugin<Config>
                 "<size=20>Damage: <color=red>" + stats.Damage + "</color>" + FormatRank(dmgRank) + " / <color=red>" + PerTen(stats.Damage, stats.TimePlayed) + "</color>" + FormatRank(dmg10Rank) + " (10m)</size>\n" +
                 "<size=20>Teamkills: <color=red>" + stats.FFKills + "</color>" + FormatRank(ffRank) + " / <color=red>" + PerTen(stats.FFKills, stats.TimePlayed) + "</color>" + FormatRank(ff10Rank) + " (10m)</size>\n" +
                 "<size=20>Deaths: <color=red>" + stats.Deaths + "</color>" + FormatRank(null) + " / <color=red>" + PerTen(stats.Deaths, stats.TimePlayed) + "</color>" + FormatRank(deaths10Rank) + " (10m)</size>\n" +
-                "<size=20>SCP kills: <color=red>" + stats.ScpsKilled + "</color> | Items: <color=red>" + stats.ScpItems + "</color></size>\n" +
-                "<size=20>Escapes: <color=red>" + stats.Escapes + "</color> | Playtime: <color=green>" + stats.TimePlayed.ToString("hh':'mm':'ss") + "</color></size>";
+                "<size=20>SCP kills: <color=red>" + stats.ScpsKilled + "</color>" + FormatRank(scpsKilledRank) +
+                " | Items: <color=red>" + stats.ScpItems + "</color>" + FormatRank(scpItemsRank) + "</size>\n" +
+                "<size=20>Escapes: <color=red>" + stats.Escapes + "</color>" + FormatRank(escapesRank) +
+                " | Playtime: <color=green>" + stats.TimePlayed.ToString("hh':'mm':'ss") + "</color></size>";
 
             player.ShowHint(hint, 7f);
         }

--- a/Main.cs
+++ b/Main.cs
@@ -75,6 +75,7 @@ public class Plugin : Plugin<Config>
         Player.Spawned += PlayerSpawned;
         Player.ActivatingGenerator += BeforeActGenerator;
         Player.PickingUpItem += pickingUpItem;
+        Player.Escaping += OnEscaping;
 
         base.OnEnabled();
         Log.Info("Plugin enabled!");
@@ -97,6 +98,7 @@ public class Plugin : Plugin<Config>
         Exiled.Events.Handlers.Map.GeneratorActivating -= GeneratorAct;
         Player.PickingUpItem -= pickingUpItem;
         Player.ActivatingGenerator -= BeforeActGenerator;
+        Player.Escaping -= OnEscaping;
         base.OnDisabled();
         Log.Info("Plugin disabled!");
     }
@@ -194,7 +196,26 @@ public class Plugin : Plugin<Config>
                 rs.DamageToScp += dmg;
         }
 
-        
+
+    }
+
+    private void OnEscaping(EscapingEventArgs ev)
+    {
+        if (!Config.Stats.Enabled)
+            return;
+
+        string id = ev.Player.UserId;
+        if (_roundStats.TryGetValue(id, out var stats))
+        {
+            var roleStats = stats.CurrentIsScp ? stats.Scp : stats.Human;
+            roleStats.Escapes++;
+            if (!stats.IsSpectator)
+            {
+                float now = (float)Round.ElapsedTime.TotalSeconds;
+                roleStats.TimeAlive += TimeSpan.FromSeconds(now - stats.AliveStart);
+                roleStats.TimePlayed += TimeSpan.FromSeconds(now - stats.ActiveStart);
+            }
+        }
     }
 
     private async void OnVerified(VerifiedEventArgs ev)

--- a/Main.cs
+++ b/Main.cs
@@ -182,9 +182,9 @@ public class Plugin : Plugin<Config>
         if (ev.Attacker == null || ev.Attacker.Id == ev.Player.Id)
             return;
 
-        int dmg = (int)ev.Amount;
-        if (ev.Attacker.Role.Type == RoleTypeId.Scp173 && dmg < 0)
-            dmg = (int)ev.Player.MaxHealth;
+        float dmg = ev.Amount;
+        if (ev.Attacker.Role.Type == RoleTypeId.Scp173 && dmg < 0f)
+            dmg = ev.Player.MaxHealth;
 
         string attackerId = ev.Attacker.UserId;
         if (_roundStats.TryGetValue(attackerId, out var st))
@@ -652,8 +652,8 @@ public class Plugin : Plugin<Config>
 
 public class RoleStats
 {
-    public int Damage;
-    public int DamageToScp;
+    public float Damage;
+    public float DamageToScp;
     public int Kills;
     public int Deaths;
     public int DeathsFromScp;

--- a/Main.cs
+++ b/Main.cs
@@ -317,9 +317,9 @@ public class Plugin : Plugin<Config>
             if (Config.Database.Enabled)
             {
                 if (stats.Human.TimePlayed > TimeSpan.Zero)
-                    _dbHelper.UpdateHumanStats(id, stats.Human);
+                    _dbHelper.UpdateHumanStats(id, new HumanDbStats(stats.Human));
                 if (stats.Scp.TimePlayed > TimeSpan.Zero)
-                    _dbHelper.UpdateScpStats(id, stats.Scp);
+                    _dbHelper.UpdateScpStats(id, new ScpDbStats(stats.Scp));
             }
         }
     }
@@ -351,9 +351,9 @@ public class Plugin : Plugin<Config>
 
             string hint =
                 "<size=22><b><color=#ffb84d>Statistics</color></b></size>\n" +
-                "<size=20>Kills: <color=red>" + stats.Kills + "</color>" + FormatRank(killsRank) + " / <color=red>" + PerTen(stats.Kills, stats.TimePlayed) + "</color></size>\n" +
-                "<size=20>Damage: <color=red>" + stats.Damage + "</color>" + FormatRank(dmgRank) + " / <color=red>" + PerTen(stats.Damage, stats.TimePlayed) + "</color></size>\n" +
-                "<size=20>Deaths: <color=red>" + stats.Deaths + "</color>" + FormatRank(deathsRank) + " / <color=red>" + PerTen(stats.Deaths, stats.TimePlayed) + "</color></size>\n" +
+                "<size=20>Kills: <color=red>" + stats.Kills + "</color>" + FormatRank(killsRank) + " / <color=red>" + PerTen(stats.Kills, stats.TimePlayed) + "</color> (10m)</size>\n" +
+                "<size=20>Damage: <color=red>" + stats.Damage + "</color>" + FormatRank(dmgRank) + " / <color=red>" + PerTen(stats.Damage, stats.TimePlayed) + "</color> (10m)</size>\n" +
+                "<size=20>Deaths: <color=red>" + stats.Deaths + "</color>" + FormatRank(deathsRank) + " / <color=red>" + PerTen(stats.Deaths, stats.TimePlayed) + "</color> (10m)</size>\n" +
                 "<size=20>Playtime: <color=green>" + stats.TimePlayed.ToString("hh':'mm':'ss") + "</color></size>";
 
             player.ShowHint(hint, 7f);
@@ -367,10 +367,10 @@ public class Plugin : Plugin<Config>
 
             string hint =
                 "<size=22><b><color=#ffb84d>Statistics</color></b></size>\n" +
-                "<size=20>Kills: <color=red>" + stats.Kills + "</color>" + FormatRank(killsRank) + " / <color=red>" + PerTen(stats.Kills, stats.TimePlayed) + "</color></size>\n" +
-                "<size=20>Damage: <color=red>" + stats.Damage + "</color>" + FormatRank(dmgRank) + " / <color=red>" + PerTen(stats.Damage, stats.TimePlayed) + "</color></size>\n" +
-                "<size=20>Teamkills: <color=red>" + stats.FFKills + "</color>" + FormatRank(ffRank) + " / <color=red>" + PerTen(stats.FFKills, stats.TimePlayed) + "</color></size>\n" +
-                "<size=20>Deaths: <color=red>" + stats.Deaths + "</color> / <color=red>" + PerTen(stats.Deaths, stats.TimePlayed) + "</color></size>\n" +
+                "<size=20>Kills: <color=red>" + stats.Kills + "</color>" + FormatRank(killsRank) + " / <color=red>" + PerTen(stats.Kills, stats.TimePlayed) + "</color> (10m)</size>\n" +
+                "<size=20>Damage: <color=red>" + stats.Damage + "</color>" + FormatRank(dmgRank) + " / <color=red>" + PerTen(stats.Damage, stats.TimePlayed) + "</color> (10m)</size>\n" +
+                "<size=20>Teamkills: <color=red>" + stats.FFKills + "</color>" + FormatRank(ffRank) + " / <color=red>" + PerTen(stats.FFKills, stats.TimePlayed) + "</color> (10m)</size>\n" +
+                "<size=20>Deaths: <color=red>" + stats.Deaths + "</color> / <color=red>" + PerTen(stats.Deaths, stats.TimePlayed) + "</color> (10m)</size>\n" +
                 "<size=20>SCP kills: <color=red>" + stats.ScpsKilled + "</color> | Items: <color=red>" + stats.ScpItems + "</color></size>\n" +
                 "<size=20>Escapes: <color=red>" + stats.Escapes + "</color> | Playtime: <color=green>" + stats.TimePlayed.ToString("hh':'mm':'ss") + "</color></size>";
 

--- a/Main.cs
+++ b/Main.cs
@@ -166,8 +166,7 @@ public class Plugin : Plugin<Config>
                             string msg = Config.Stats.TeamkillMessage.Replace("{killer}", ev.Attacker.Nickname)
                                 .Replace("{victim}", ev.Player.Nickname)
                                 .Replace("{count}", att.FFKills.ToString());
-                            foreach (var pl in Exiled.API.Features.Player.List)
-                                pl.Broadcast(10, msg, Broadcast.BroadcastFlags.Normal, true);
+                            Map.Broadcast(10, msg, Broadcast.BroadcastFlags.Normal, true);
                         }
                     }
                 }

--- a/Main.cs
+++ b/Main.cs
@@ -441,9 +441,9 @@ public class Plugin : Plugin<Config>
 
             string hint =
                 "<size=22><b><color=#ffb84d>Statistics</color></b></size>\n" +
-                "<size=20>Kills: <color=red>" + stats.Kills + "</color>" + FormatRank(killsRank) + " / <color=red>" + PerTen(stats.Kills, stats.TimePlayed) + "</color>" + FormatRank(kills10Rank) + " (10m)</size>\n" +
-                "<size=20>Damage: <color=red>" + stats.Damage + "</color>" + FormatRank(dmgRank) + " / <color=red>" + PerTen(stats.Damage, stats.TimePlayed) + "</color>" + FormatRank(dmg10Rank) + " (10m)</size>\n" +
-                "<size=20>Deaths: <color=red>" + stats.Deaths + "</color>" + FormatRank(deathsRank) + " / <color=red>" + PerTen(stats.Deaths, stats.TimePlayed) + "</color>" + FormatRank(deaths10Rank) + " (10m)</size>\n" +
+                "<size=20>Kills: <color=red>" + stats.Kills + "</color>" + FormatRank(killsRank) + " / <color=red>" + PerTen(stats.Kills, stats.TimePlayed) + "</color>" + FormatRank(kills10Rank) + " (avg for 10m)</size>\n" +
+                "<size=20>Damage: <color=red>" + stats.Damage + "</color>" + FormatRank(dmgRank) + " / <color=red>" + PerTen(stats.Damage, stats.TimePlayed) + "</color>" + FormatRank(dmg10Rank) + " (avg for 10m)</size>\n" +
+                "<size=20>Deaths: <color=red>" + stats.Deaths + "</color>" + FormatRank(deathsRank) + " / <color=red>" + PerTen(stats.Deaths, stats.TimePlayed) + "</color>" + FormatRank(deaths10Rank) + " (avg for 10m)</size>\n" +
                 "<size=20>Playtime: <color=green>" + stats.TimePlayed.ToString("hh':'mm':'ss") + "</color></size>";
 
             player.ShowHint(hint, 7f);
@@ -464,16 +464,16 @@ public class Plugin : Plugin<Config>
 
             string hint =
                 "<size=22><b><color=#ffb84d>Statistics</color></b></size>\n" +
-                "<size=20>Kills: <color=red>" + stats.Kills + "</color>" + FormatRank(killsRank) + " / <color=red>" + PerTen(stats.Kills, stats.TimePlayed) + "</color>" + FormatRank(kills10Rank) + " (10m)</size>\n" +
-                "<size=20>Damage: <color=red>" + stats.Damage + "</color>" + FormatRank(dmgRank) + " / <color=red>" + PerTen(stats.Damage, stats.TimePlayed) + "</color>" + FormatRank(dmg10Rank) + " (10m)</size>\n" +
-                "<size=20>Teamkills: <color=red>" + stats.FFKills + "</color>" + FormatRank(ffRank) + " / <color=red>" + PerTen(stats.FFKills, stats.TimePlayed) + "</color>" + FormatRank(ff10Rank) + " (10m)</size>\n" +
-                "<size=20>Deaths: <color=red>" + stats.Deaths + "</color>" + FormatRank(null) + " / <color=red>" + PerTen(stats.Deaths, stats.TimePlayed) + "</color>" + FormatRank(deaths10Rank) + " (10m)</size>\n" +
+                "<size=20>Kills: <color=red>" + stats.Kills + "</color>" + FormatRank(killsRank) + " / <color=red>" + PerTen(stats.Kills, stats.TimePlayed) + "</color>" + FormatRank(kills10Rank) + " (avg for 10m)</size>\n" +
+                "<size=20>Damage: <color=red>" + stats.Damage + "</color>" + FormatRank(dmgRank) + " / <color=red>" + PerTen(stats.Damage, stats.TimePlayed) + "</color>" + FormatRank(dmg10Rank) + " (avg for 10m)</size>\n" +
+                "<size=20>Teamkills: <color=red>" + stats.FFKills + "</color>" + FormatRank(ffRank) + " / <color=red>" + PerTen(stats.FFKills, stats.TimePlayed) + "</color>" + FormatRank(ff10Rank) + " (avg for 10m)</size>\n" +
+                "<size=20>Deaths: <color=red>" + stats.Deaths + "</color>" + FormatRank(null) + " / <color=red>" + PerTen(stats.Deaths, stats.TimePlayed) + "</color>" + FormatRank(deaths10Rank) + " (avg for 10m)</size>\n" +
                 "<size=20>SCP kills: <color=red>" + stats.ScpsKilled + "</color>" + FormatRank(scpsKilledRank) +
                 " | Items: <color=red>" + stats.ScpItems + "</color>" + FormatRank(scpItemsRank) + "</size>\n" +
                 "<size=20>Escapes: <color=red>" + stats.Escapes + "</color>" + FormatRank(escapesRank) +
                 " | Playtime: <color=green>" + stats.TimePlayed.ToString("hh':'mm':'ss") + "</color></size>";
 
-            player.ShowHint(hint, 7f);
+            player.ShowHint(hint, 11f);
         }
     }
 

--- a/Main.cs
+++ b/Main.cs
@@ -348,12 +348,15 @@ public class Plugin : Plugin<Config>
             var killsRank = await _dbHelper.GetStatRankAsync(id, "kills", "scp_stats");
             var dmgRank = await _dbHelper.GetStatRankAsync(id, "damage", "scp_stats");
             var deathsRank = await _dbHelper.GetStatRankAsync(id, "deaths", "scp_stats");
+            var kills10Rank = await _dbHelper.GetStatRankAsync(id, "kills_10m", "scp_stats");
+            var dmg10Rank = await _dbHelper.GetStatRankAsync(id, "damage_10m", "scp_stats");
+            var deaths10Rank = await _dbHelper.GetStatRankAsync(id, "deaths_10m", "scp_stats");
 
             string hint =
                 "<size=22><b><color=#ffb84d>Statistics</color></b></size>\n" +
-                "<size=20>Kills: <color=red>" + stats.Kills + "</color>" + FormatRank(killsRank) + " / <color=red>" + PerTen(stats.Kills, stats.TimePlayed) + "</color> (10m)</size>\n" +
-                "<size=20>Damage: <color=red>" + stats.Damage + "</color>" + FormatRank(dmgRank) + " / <color=red>" + PerTen(stats.Damage, stats.TimePlayed) + "</color> (10m)</size>\n" +
-                "<size=20>Deaths: <color=red>" + stats.Deaths + "</color>" + FormatRank(deathsRank) + " / <color=red>" + PerTen(stats.Deaths, stats.TimePlayed) + "</color> (10m)</size>\n" +
+                "<size=20>Kills: <color=red>" + stats.Kills + "</color>" + FormatRank(killsRank) + " / <color=red>" + PerTen(stats.Kills, stats.TimePlayed) + "</color>" + FormatRank(kills10Rank) + " (10m)</size>\n" +
+                "<size=20>Damage: <color=red>" + stats.Damage + "</color>" + FormatRank(dmgRank) + " / <color=red>" + PerTen(stats.Damage, stats.TimePlayed) + "</color>" + FormatRank(dmg10Rank) + " (10m)</size>\n" +
+                "<size=20>Deaths: <color=red>" + stats.Deaths + "</color>" + FormatRank(deathsRank) + " / <color=red>" + PerTen(stats.Deaths, stats.TimePlayed) + "</color>" + FormatRank(deaths10Rank) + " (10m)</size>\n" +
                 "<size=20>Playtime: <color=green>" + stats.TimePlayed.ToString("hh':'mm':'ss") + "</color></size>";
 
             player.ShowHint(hint, 7f);
@@ -364,13 +367,17 @@ public class Plugin : Plugin<Config>
             var killsRank = await _dbHelper.GetStatRankAsync(id, "kills", "human_stats");
             var dmgRank = await _dbHelper.GetStatRankAsync(id, "damage", "human_stats");
             var ffRank = await _dbHelper.GetStatRankAsync(id, "ff_kills", "human_stats");
+            var kills10Rank = await _dbHelper.GetStatRankAsync(id, "kills_10m", "human_stats");
+            var dmg10Rank = await _dbHelper.GetStatRankAsync(id, "damage_10m", "human_stats");
+            var ff10Rank = await _dbHelper.GetStatRankAsync(id, "ff_kills_10m", "human_stats");
+            var deaths10Rank = await _dbHelper.GetStatRankAsync(id, "deaths_10m", "human_stats");
 
             string hint =
                 "<size=22><b><color=#ffb84d>Statistics</color></b></size>\n" +
-                "<size=20>Kills: <color=red>" + stats.Kills + "</color>" + FormatRank(killsRank) + " / <color=red>" + PerTen(stats.Kills, stats.TimePlayed) + "</color> (10m)</size>\n" +
-                "<size=20>Damage: <color=red>" + stats.Damage + "</color>" + FormatRank(dmgRank) + " / <color=red>" + PerTen(stats.Damage, stats.TimePlayed) + "</color> (10m)</size>\n" +
-                "<size=20>Teamkills: <color=red>" + stats.FFKills + "</color>" + FormatRank(ffRank) + " / <color=red>" + PerTen(stats.FFKills, stats.TimePlayed) + "</color> (10m)</size>\n" +
-                "<size=20>Deaths: <color=red>" + stats.Deaths + "</color> / <color=red>" + PerTen(stats.Deaths, stats.TimePlayed) + "</color> (10m)</size>\n" +
+                "<size=20>Kills: <color=red>" + stats.Kills + "</color>" + FormatRank(killsRank) + " / <color=red>" + PerTen(stats.Kills, stats.TimePlayed) + "</color>" + FormatRank(kills10Rank) + " (10m)</size>\n" +
+                "<size=20>Damage: <color=red>" + stats.Damage + "</color>" + FormatRank(dmgRank) + " / <color=red>" + PerTen(stats.Damage, stats.TimePlayed) + "</color>" + FormatRank(dmg10Rank) + " (10m)</size>\n" +
+                "<size=20>Teamkills: <color=red>" + stats.FFKills + "</color>" + FormatRank(ffRank) + " / <color=red>" + PerTen(stats.FFKills, stats.TimePlayed) + "</color>" + FormatRank(ff10Rank) + " (10m)</size>\n" +
+                "<size=20>Deaths: <color=red>" + stats.Deaths + "</color>" + FormatRank(null) + " / <color=red>" + PerTen(stats.Deaths, stats.TimePlayed) + "</color>" + FormatRank(deaths10Rank) + " (10m)</size>\n" +
                 "<size=20>SCP kills: <color=red>" + stats.ScpsKilled + "</color> | Items: <color=red>" + stats.ScpItems + "</color></size>\n" +
                 "<size=20>Escapes: <color=red>" + stats.Escapes + "</color> | Playtime: <color=green>" + stats.TimePlayed.ToString("hh':'mm':'ss") + "</color></size>";
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The resulting `MaxunPlugin.dll` will be in `bin/Release/net48`.
 3.  Copy all files from the `ExiledDependencies` folder to `.config/EXILED/Plugins/Dependencies`.
 4. Restart the server to generate a configuration file.
 
+The plugin creates the statistics tables automatically if they are missing.
+
 ## Configuration
 
 After first launch, edit `MaxunPlugin.yml` in the `Exiled/Configs` directory. Below is an example configuration with default values:
@@ -59,6 +61,8 @@ debug: false
 database:
   enabled: true
   connection_string: "Server=localhost;Database=scp_db;User ID=scp_user;Password=scp_password;Pooling=true;"
+  human_table: human_stats
+  scp_table: scp_stats
 
 blackout:
   enabled: true


### PR DESCRIPTION
## Summary
- overhaul stats and database logic
- split persistent stats by SCP and human
- track ally kills using configurable broadcast
- restructure player hint to show role-specific stats

## Testing
- `dotnet build -c Release` *(fails: StoppingEventArgs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68750ca377288324a378333f37f7c434

## Summary by Sourcery

Полностью переработана система отслеживания статистики для использования унифицированной модели RoleStats для каждого раунда с отдельными показателями для людей и SCP, поддерживаемой новыми таблицами базы данных для постоянного отслеживания human_stats и scp_stats.

Новые возможности:
- Добавлена настраиваемая трансляция убийства союзника (teamkill) с пользовательским сообщением, порогом и флагом включения.
- Отображение внутриигровой подсказки для конкретной роли, показывающей убийства, урон, смерти, время игры и показатели за 10 минут.

Улучшения:
- Замена устаревших PlayerStats/PlayerLifeStats на RoundPlayerStats и RoleStats для консолидации отслеживания в памяти.
- Отслеживание подробных показателей, включая смерти от SCP/человека, время жизни и время игры.
- Реструктуризация MyDatabaseHelper для инициализации и обновления отдельных таблиц human_stats и scp_stats.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the entire stats tracking system to use a unified per-round RoleStats model with separate human and SCP metrics, backed by new database tables for persistent human_stats and scp_stats tracking.

New Features:
- Add configurable teamkill broadcast with custom message, threshold, and enable flag
- Display role-specific in-game hint showing kills, damage, deaths, playtime, and per-10-minute rates

Enhancements:
- Replace legacy PlayerStats/PlayerLifeStats with RoundPlayerStats and RoleStats to consolidate in-memory tracking
- Track detailed metrics including deaths from SCP/human, time alive, and time played
- Restructure MyDatabaseHelper to initialize and update separate human_stats and scp_stats tables

</details>