### PR TITLE
Implement table auto creation

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -75,6 +75,12 @@ namespace MaxunPlugin
         [Description("Connection string for the MySQL database.")]
         public string ConnectionString { get; set; } =
             "Server=localhost;Database=scp_db;User ID=scp_user;Password=scp_password;Pooling=true;";
+
+        [Description("Table name for human player statistics.")]
+        public string HumanTable { get; set; } = "human_stats";
+
+        [Description("Table name for SCP statistics.")]
+        public string ScpTable { get; set; } = "scp_stats";
     }
 
     public class BlackoutModule : ModuleBase

--- a/DB_Helper.cs
+++ b/DB_Helper.cs
@@ -1,15 +1,21 @@
 using Exiled.API.Features;
 using MySql.Data.MySqlClient;
+using System;
+using System.Threading.Tasks;
 
 namespace MaxunPlugin;
 
 public class MyDatabaseHelper
 {
     private readonly string _connectionString;
+    private readonly string _humanTable;
+    private readonly string _scpTable;
 
-    public MyDatabaseHelper(string connectionString)
+    public MyDatabaseHelper(string connectionString, string humanTable, string scpTable)
     {
         _connectionString = connectionString;
+        _humanTable = humanTable;
+        _scpTable = scpTable;
     }
 
     public async Task TestConnectionAsync()
@@ -21,12 +27,57 @@ public class MyDatabaseHelper
         Log.Info("MySQL version: " + result);
     }
 
+    public async Task EnsureTablesAsync()
+    {
+        using var conn = new MySqlConnection(_connectionString);
+        await conn.OpenAsync();
+
+        var humanCmd = new MySqlCommand($@"CREATE TABLE IF NOT EXISTS `{_humanTable}` (
+            ID VARCHAR(64) NOT NULL PRIMARY KEY,
+            nickname VARCHAR(32) NOT NULL,
+            damage INT NOT NULL DEFAULT 0,
+                kills INT NOT NULL DEFAULT 0,
+                deaths INT NOT NULL DEFAULT 0,
+                deaths_scp INT NOT NULL DEFAULT 0,
+                deaths_human INT NOT NULL DEFAULT 0,
+                scp_items INT NOT NULL DEFAULT 0,
+                scps_killed INT NOT NULL DEFAULT 0,
+                ff_kills INT NOT NULL DEFAULT 0,
+                escapes INT NOT NULL DEFAULT 0,
+                damage_to_scp INT NOT NULL DEFAULT 0,
+                time_played TIME NOT NULL DEFAULT '00:00:00',
+                time_alive TIME NOT NULL DEFAULT '00:00:00',
+                damage_10m DOUBLE NOT NULL DEFAULT 0,
+                kills_10m DOUBLE NOT NULL DEFAULT 0,
+                ff_kills_10m DOUBLE NOT NULL DEFAULT 0,
+                deaths_10m DOUBLE NOT NULL DEFAULT 0
+            );", conn);
+        await humanCmd.ExecuteNonQueryAsync();
+
+        var scpCmd = new MySqlCommand($@"CREATE TABLE IF NOT EXISTS `{_scpTable}` (
+            ID VARCHAR(64) NOT NULL PRIMARY KEY,
+            nickname VARCHAR(32) NOT NULL,
+            damage INT NOT NULL DEFAULT 0,
+                kills INT NOT NULL DEFAULT 0,
+                deaths INT NOT NULL DEFAULT 0,
+                deaths_scp INT NOT NULL DEFAULT 0,
+                deaths_human INT NOT NULL DEFAULT 0,
+                damage_to_scp INT NOT NULL DEFAULT 0,
+                time_played TIME NOT NULL DEFAULT '00:00:00',
+                time_alive TIME NOT NULL DEFAULT '00:00:00',
+                damage_10m DOUBLE NOT NULL DEFAULT 0,
+                kills_10m DOUBLE NOT NULL DEFAULT 0,
+                deaths_10m DOUBLE NOT NULL DEFAULT 0
+            );", conn);
+        await scpCmd.ExecuteNonQueryAsync();
+    }
+
     public async Task CreateRow(string id, string nickname)
     {
         using var conn = new MySqlConnection(_connectionString);
         await conn.OpenAsync();
         var cmdHuman = new MySqlCommand(
-            "INSERT IGNORE INTO human_stats (ID,nickname,damage,kills,deaths,deaths_scp,deaths_human,scp_items,scps_killed,ff_kills,escapes,damage_to_scp,time_played,time_alive,damage_10m,kills_10m,ff_kills_10m,deaths_10m) " +
+            $"INSERT IGNORE INTO `{_humanTable}` (ID,nickname,damage,kills,deaths,deaths_scp,deaths_human,scp_items,scps_killed,ff_kills,escapes,damage_to_scp,time_played,time_alive,damage_10m,kills_10m,ff_kills_10m,deaths_10m) " +
             "VALUES (@id,@n,0,0,0,0,0,0,0,0,0,0,'00:00:00','00:00:00',0,0,0,0);",
             conn);
         cmdHuman.Parameters.AddWithValue("@id", id);
@@ -34,7 +85,7 @@ public class MyDatabaseHelper
         await cmdHuman.ExecuteNonQueryAsync();
 
         var cmdScp = new MySqlCommand(
-            "INSERT IGNORE INTO scp_stats (ID,nickname,damage,kills,deaths,deaths_scp,deaths_human,damage_to_scp,time_played,time_alive,damage_10m,kills_10m,deaths_10m) " +
+            $"INSERT IGNORE INTO `{_scpTable}` (ID,nickname,damage,kills,deaths,deaths_scp,deaths_human,damage_to_scp,time_played,time_alive,damage_10m,kills_10m,deaths_10m) " +
             "VALUES (@id,@n,0,0,0,0,0,0,'00:00:00','00:00:00',0,0,0);",
             conn);
         cmdScp.Parameters.AddWithValue("@id", id);
@@ -47,7 +98,7 @@ public class MyDatabaseHelper
         using var conn = new MySqlConnection(_connectionString);
         await conn.OpenAsync();
         var cmd = new MySqlCommand(
-            "UPDATE human_stats SET nickname=@n WHERE ID=@id; UPDATE scp_stats SET nickname=@n WHERE ID=@id;",
+            $"UPDATE `{_humanTable}` SET nickname=@n WHERE ID=@id; UPDATE `{_scpTable}` SET nickname=@n WHERE ID=@id;",
             conn);
         cmd.Parameters.AddWithValue("@id", id);
         cmd.Parameters.AddWithValue("@n", nickname);
@@ -59,7 +110,7 @@ public class MyDatabaseHelper
         using var conn = new MySqlConnection(_connectionString);
         await conn.OpenAsync();
         var cmd = new MySqlCommand(
-            @"UPDATE human_stats
+            @$"UPDATE `{_humanTable}`
               SET damage = damage + @dmg,
                   kills = kills + @k,
                   deaths = deaths + @de,
@@ -99,7 +150,7 @@ public class MyDatabaseHelper
         using var conn = new MySqlConnection(_connectionString);
         await conn.OpenAsync();
         var cmd = new MySqlCommand(
-            @"UPDATE scp_stats
+            @$"UPDATE `{_scpTable}`
               SET damage = damage + @dmg,
                   kills = kills + @k,
                   deaths = deaths + @de,
@@ -131,7 +182,7 @@ public class MyDatabaseHelper
         var stats = new HumanDbStats();
         await conn.OpenAsync();
         var cmd = new MySqlCommand(
-            "SELECT damage,kills,deaths,deaths_scp,deaths_human,scp_items,scps_killed,ff_kills,escapes,damage_to_scp,time_played,time_alive,damage_10m,kills_10m,ff_kills_10m,deaths_10m FROM human_stats WHERE ID=@id;",
+            $"SELECT damage,kills,deaths,deaths_scp,deaths_human,scp_items,scps_killed,ff_kills,escapes,damage_to_scp,time_played,time_alive,damage_10m,kills_10m,ff_kills_10m,deaths_10m FROM `{_humanTable}` WHERE ID=@id;",
             conn);
         cmd.Parameters.AddWithValue("@id", id);
         using var reader = (MySqlDataReader)await cmd.ExecuteReaderAsync();
@@ -163,7 +214,7 @@ public class MyDatabaseHelper
         var stats = new ScpDbStats();
         await conn.OpenAsync();
         var cmd = new MySqlCommand(
-            "SELECT damage,kills,deaths,deaths_scp,deaths_human,damage_to_scp,time_played,time_alive,damage_10m,kills_10m,deaths_10m FROM scp_stats WHERE ID=@id;",
+            $"SELECT damage,kills,deaths,deaths_scp,deaths_human,damage_to_scp,time_played,time_alive,damage_10m,kills_10m,deaths_10m FROM `{_scpTable}` WHERE ID=@id;",
             conn);
         cmd.Parameters.AddWithValue("@id", id);
         using var reader = (MySqlDataReader)await cmd.ExecuteReaderAsync();

--- a/Main.cs
+++ b/Main.cs
@@ -54,8 +54,12 @@ public class Plugin : Plugin<Config>
         }
         if (Config.Database.Enabled)
         {
-            _dbHelper = new MyDatabaseHelper(Config.Database.ConnectionString);
+            _dbHelper = new MyDatabaseHelper(
+                Config.Database.ConnectionString,
+                Config.Database.HumanTable,
+                Config.Database.ScpTable);
             _dbHelper.TestConnectionAsync();
+            _dbHelper.EnsureTablesAsync().GetAwaiter().GetResult();
         }
 
         Player.Died += OnDie;
@@ -345,12 +349,12 @@ public class Plugin : Plugin<Config>
         if (player.Role.Side == Side.Scp)
         {
             var stats = await _dbHelper.GetScpStatsAsync(id);
-            var killsRank = await _dbHelper.GetStatRankAsync(id, "kills", "scp_stats");
-            var dmgRank = await _dbHelper.GetStatRankAsync(id, "damage", "scp_stats");
-            var deathsRank = await _dbHelper.GetStatRankAsync(id, "deaths", "scp_stats");
-            var kills10Rank = await _dbHelper.GetStatRankAsync(id, "kills_10m", "scp_stats");
-            var dmg10Rank = await _dbHelper.GetStatRankAsync(id, "damage_10m", "scp_stats");
-            var deaths10Rank = await _dbHelper.GetStatRankAsync(id, "deaths_10m", "scp_stats");
+            var killsRank = await _dbHelper.GetStatRankAsync(id, "kills", Config.Database.ScpTable);
+            var dmgRank = await _dbHelper.GetStatRankAsync(id, "damage", Config.Database.ScpTable);
+            var deathsRank = await _dbHelper.GetStatRankAsync(id, "deaths", Config.Database.ScpTable);
+            var kills10Rank = await _dbHelper.GetStatRankAsync(id, "kills_10m", Config.Database.ScpTable);
+            var dmg10Rank = await _dbHelper.GetStatRankAsync(id, "damage_10m", Config.Database.ScpTable);
+            var deaths10Rank = await _dbHelper.GetStatRankAsync(id, "deaths_10m", Config.Database.ScpTable);
 
             string hint =
                 "<size=22><b><color=#ffb84d>Statistics</color></b></size>\n" +
@@ -364,13 +368,13 @@ public class Plugin : Plugin<Config>
         else
         {
             var stats = await _dbHelper.GetHumanStatsAsync(id);
-            var killsRank = await _dbHelper.GetStatRankAsync(id, "kills", "human_stats");
-            var dmgRank = await _dbHelper.GetStatRankAsync(id, "damage", "human_stats");
-            var ffRank = await _dbHelper.GetStatRankAsync(id, "ff_kills", "human_stats");
-            var kills10Rank = await _dbHelper.GetStatRankAsync(id, "kills_10m", "human_stats");
-            var dmg10Rank = await _dbHelper.GetStatRankAsync(id, "damage_10m", "human_stats");
-            var ff10Rank = await _dbHelper.GetStatRankAsync(id, "ff_kills_10m", "human_stats");
-            var deaths10Rank = await _dbHelper.GetStatRankAsync(id, "deaths_10m", "human_stats");
+            var killsRank = await _dbHelper.GetStatRankAsync(id, "kills", Config.Database.HumanTable);
+            var dmgRank = await _dbHelper.GetStatRankAsync(id, "damage", Config.Database.HumanTable);
+            var ffRank = await _dbHelper.GetStatRankAsync(id, "ff_kills", Config.Database.HumanTable);
+            var kills10Rank = await _dbHelper.GetStatRankAsync(id, "kills_10m", Config.Database.HumanTable);
+            var dmg10Rank = await _dbHelper.GetStatRankAsync(id, "damage_10m", Config.Database.HumanTable);
+            var ff10Rank = await _dbHelper.GetStatRankAsync(id, "ff_kills_10m", Config.Database.HumanTable);
+            var deaths10Rank = await _dbHelper.GetStatRankAsync(id, "deaths_10m", Config.Database.HumanTable);
 
             string hint =
                 "<size=22><b><color=#ffb84d>Statistics</color></b></size>\n" +

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ debug: false
 database:
   enabled: true
   connection_string: "Server=localhost;Database=scp_db;User ID=scp_user;Password=scp_password;Pooling=true;"
+  human_table: human_stats
+  scp_table: scp_stats
 
 blackout:
   enabled: true


### PR DESCRIPTION
## Summary
- configure stats table names in config
- create stats tables automatically on plugin load
- document table names in README

## Testing
- `dotnet build -c Release` *(fails: Missing Exiled assemblies)*

------
https://chatgpt.com/codex/tasks/task_e_68754974d8b483248bc7ebfaf4d12f74