### PR TITLE
Fix low-damage stats recording

### DIFF
--- a/DB_Helper.cs
+++ b/DB_Helper.cs
@@ -293,7 +293,7 @@ public class HumanDbStats
 
     public HumanDbStats(Plugin.RoleStats r)
     {
-        Damage = r.Damage;
+        Damage = (int)Math.Round(r.Damage);
         Kills = r.Kills;
         Deaths = r.Deaths;
         DeathsFromScp = r.DeathsFromScp;
@@ -302,7 +302,7 @@ public class HumanDbStats
         ScpsKilled = r.ScpsKilled;
         FFKills = r.FFKills;
         Escapes = r.Escapes;
-        DamageToScp = r.DamageToScp;
+        DamageToScp = (int)Math.Round(r.DamageToScp);
         TimePlayed = r.TimePlayed;
         TimeAlive = r.TimeAlive;
         DamagePerTen = 0;
@@ -330,12 +330,12 @@ public class ScpDbStats
 
     public ScpDbStats(Plugin.RoleStats r)
     {
-        Damage = r.Damage;
+        Damage = (int)Math.Round(r.Damage);
         Kills = r.Kills;
         Deaths = r.Deaths;
         DeathsFromScp = r.DeathsFromScp;
         DeathsFromHuman = r.DeathsFromHuman;
-        DamageToScp = r.DamageToScp;
+        DamageToScp = (int)Math.Round(r.DamageToScp);
         TimePlayed = r.TimePlayed;
         TimeAlive = r.TimeAlive;
         DamagePerTen = 0;

--- a/Main.cs
+++ b/Main.cs
@@ -182,9 +182,9 @@ public class Plugin : Plugin<Config>
         if (ev.Attacker == null || ev.Attacker.Id == ev.Player.Id)
             return;
 
-        int dmg = (int)ev.Amount;
-        if (ev.Attacker.Role.Type == RoleTypeId.Scp173 && dmg < 0)
-            dmg = (int)ev.Player.MaxHealth;
+        float dmg = ev.Amount;
+        if (ev.Attacker.Role.Type == RoleTypeId.Scp173 && dmg < 0f)
+            dmg = ev.Player.MaxHealth;
 
         string attackerId = ev.Attacker.UserId;
         if (_roundStats.TryGetValue(attackerId, out var st))
@@ -652,8 +652,8 @@ public class Plugin : Plugin<Config>
 
 public class RoleStats
 {
-    public int Damage;
-    public int DamageToScp;
+    public float Damage;
+    public float DamageToScp;
     public int Kills;
     public int Deaths;
     public int DeathsFromScp;


### PR DESCRIPTION
## Summary
- keep fractional damage when tracking player hits
- round damage when saving to the database

## Testing
- `dotnet build -c Release` *(fails: missing Exiled and game assemblies)*

------
https://chatgpt.com/codex/tasks/task_e_687558879db883249218ac3db43d85b2

## Обзор от Sourcery

Сохранение дробного урона в статистике времени выполнения путем переключения полей урона на float и применения округления только при сохранении статистики в базе данных.

Исправления ошибок:
- Предотвращение потери дробных значений урона при отслеживании попаданий игрока.

Улучшения:
- Хранение статистики урона в виде чисел с плавающей запятой (floats) во время раунда для сохранения точности.
- Округление значений урона при преобразовании статистики в записи базы данных.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve fractional damage in runtime statistics by switching damage fields to float and apply rounding only when saving stats to the database

Bug Fixes:
- Prevent loss of fractional damage values when tracking player hits

Enhancements:
- Store damage stats as floats during the round to preserve precision
- Round damage values when converting stats to database records

</details>