### PR TITLE
Implement escapes tracking

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -215,7 +215,6 @@ public class Plugin : Plugin<Config>
                 float now = (float)Round.ElapsedTime.TotalSeconds;
                 roleStats.TimeAlive += TimeSpan.FromSeconds(now - stats.AliveStart);
                 roleStats.TimePlayed += TimeSpan.FromSeconds(now - stats.ActiveStart);
-                stats.IsSpectator = true;
             }
         }
     }


### PR DESCRIPTION
## Summary
- register `Player.Escaping` event in plugin
- increment escape statistics when players successfully escape

## Testing
- `dotnet build -c Release` *(fails: missing game assemblies)*

------
https://chatgpt.com/codex/tasks/task_e_68755cc07b9c8324b0c7eeab994f7b95

## Обзор от Sourcery

Добавлено отслеживание событий побега игрока для обновления статистики побегов и данных о времени для каждого игрока

Новые возможности:
- Регистрация и отмена регистрации события `Player.Escaping` в жизненном цикле включения/выключения плагина

Улучшения:
- Обработка события `Player.Escaping` для увеличения количества побегов, обновления времени жизни и времени игры, а также отметки игроков как зрителей

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add tracking of player escape events to update per-player escape statistics and timing data

New Features:
- Register and unregister the Player.Escaping event in the plugin enable/disable lifecycle

Enhancements:
- Handle the Player.Escaping event to increment escape counts, update time alive and time played, and mark players as spectators

</details>