### PR TITLE
Fix teamkill broadcast

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -166,8 +166,7 @@ public class Plugin : Plugin<Config>
                             string msg = Config.Stats.TeamkillMessage.Replace("{killer}", ev.Attacker.Nickname)
                                 .Replace("{victim}", ev.Player.Nickname)
                                 .Replace("{count}", att.FFKills.ToString());
-                            foreach (var pl in Exiled.API.Features.Player.List)
-                                pl.Broadcast(10, msg, Broadcast.BroadcastFlags.Normal, true);
+                            Map.Broadcast(10, msg, Broadcast.BroadcastFlags.Normal, true);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- broadcast excessive teamkill warning via Map.Broadcast

## Testing
- `dotnet build -c Release` *(fails: missing Exiled dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68755e7b14a08324a3d3595a89356a36

## Обзор от Sourcery

Исправления ошибок:
- Замена Broadcast для каждого игрока на Map.Broadcast для предупреждений об убийстве союзников

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Replace per-player Broadcast with Map.Broadcast for teamkill warnings

</details>