### PR TITLE
Add end-of-round statistics broadcast

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -310,6 +310,31 @@ public class Plugin : Plugin<Config>
         }
         if (Config.AutoBomb.Enabled)
             Timing.KillCoroutines(_warheadCoroutine);
+        int maxKills = 0;
+        string maxKiller = string.Empty;
+
+        foreach (var pl in Exiled.API.Features.Player.List)
+        {
+            string pid = pl.UserId;
+            if (!_roundStats.TryGetValue(pid, out var pStats))
+                continue;
+
+            int kills = pStats.Human.Kills + pStats.Scp.Kills;
+            int ff = pStats.Human.FFKills;
+
+            if (Config.Stats.Enabled && kills - ff > maxKills)
+            {
+                maxKills = kills - ff;
+                maxKiller = pl.Nickname;
+            }
+        }
+
+        string word = "убийств";
+        if (maxKills != 0)
+            word = CalculateRightWord(maxKills);
+        else
+            maxKiller = "никто";
+
         foreach (var player in Exiled.API.Features.Player.List)
         {
             string id = player.UserId;
@@ -336,6 +361,19 @@ public class Plugin : Plugin<Config>
                     Log.Info($"Updating SCP stats for {id}");
                     await _dbHelper.UpdateScpStats(id, new ScpDbStats(stats.Scp));
                 }
+            }
+
+            if (Config.Stats.Enabled)
+            {
+                int dmg = (int)Math.Round(stats.Human.Damage + stats.Scp.Damage);
+                int kills = stats.Human.Kills + stats.Scp.Kills;
+                int ff = stats.Human.FFKills;
+
+                player.Broadcast(7,
+                    "Вы убили " + "<color=red>" + kills + "</color>" + " человек, из них союзников - " +
+                    "<color=red>" + ff + "</color>" + ". Всего нанесено урона: " +
+                    "<color=red>" + dmg + "</color>\n" + "Самый результативный игрок - " + "<color=red>" +
+                    maxKiller + "</color>" + " с " + "<color=red>" + maxKills + " </color>" + word);
             }
         }
     }


### PR DESCRIPTION
## Summary
- send per-player stats broadcast when the round ends

## Testing
- `dotnet build -c Release` *(fails: Exiled and Unity assemblies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68755fe4af008324af3ed4f8a092a7f3

## Краткое описание от Sourcery

Реализация функции статистики в конце раунда для расчета и трансляции данных об эффективности каждого игрока и лучшего убийцы раунда.

Новые функции:
- Расчет самого эффективного игрока по числу убийств в конце раунда
- Трансляция количества убийств, убийств союзников и общего урона каждого игрока в конце раунда, а также лучшего убийцы

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement end-of-round statistics feature to calculate and broadcast per-player performance and the round’s top killer

New Features:
- Calculate the most effective player by net kills at round end
- Broadcast each player's kills, friendly fire kills, and total damage at round end, along with the top killer

</details>