### PR TITLE
Add remote admin log import

### DIFF
--- a/Logging.cs
+++ b/Logging.cs
@@ -88,6 +88,7 @@ namespace MaxunPlugin
 
             Warhead.Detonated += OnWarheadDetonated;
             Warhead.Starting += OnWarheadStarting;
+            Warhead.Stopping += OnWarheadStopping;
             Warhead.DeadmanSwitchInitiating += OnDeadmanSwitch;
             Warhead.Detonating += OnWarheadDetonating;
             Warhead.ChangingLeverStatus += OnChangingLever;
@@ -132,6 +133,7 @@ namespace MaxunPlugin
 
             Warhead.Detonated -= OnWarheadDetonated;
             Warhead.Starting -= OnWarheadStarting;
+            Warhead.Stopping -= OnWarheadStopping;
             Warhead.DeadmanSwitchInitiating -= OnDeadmanSwitch;
             Warhead.Detonating -= OnWarheadDetonating;
             Warhead.ChangingLeverStatus -= OnChangingLever;
@@ -388,6 +390,10 @@ namespace MaxunPlugin
         private void OnWarheadStarting(StartingEventArgs ev)
         {
             Write("Game Event", "Warhead", "Warhead starting");
+        }
+        private void OnWarheadStopping(StoppingEventArgs ev)
+        {
+            Write("Game Event", "Warhead", "Warhead stopping");
         }
         private void OnDeadmanSwitch(DeadmanSwitchInitiatingEventArgs ev)
         {


### PR DESCRIPTION
## Summary
- import Remote Admin events from official server logs into round log
- handle repeated reads and server restarts
- merge imported Remote Admin lines into the round log chronologically

## Testing
- `dotnet build` *(fails: Exiled and game assemblies missing)*

------

## Сводка от Sourcery

Добавлена функциональность для добавления событий Remote Admin из логов сервера в лог раунда, обработки повторных чтений и перезапусков, а также обеспечения хронологического слияния записей логов.

Новые функции:
- Импорт событий Remote Admin из официальных логов сервера в лог раунда

Улучшения:
- Отслеживание последнего обработанного файла и строки лога RA для предотвращения дублирующего импорта
- Объединение импортированных строк RA в лог раунда в хронологическом порядке
- Использование FileStream с совместным доступом ReadWrite для записи логов и отслеживание текущего пути к файлу лога
- Автоматический импорт логов RA по окончании раунда и при перезапуске
- Удаление обработчика событий Warhead.Stopping и связанного с ним метода

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add functionality to append Remote Admin events from server logs into the round log, handle repeated reads and restarts, and ensure chronological merging of log entries

New Features:
- Import Remote Admin events from official server logs into the round log

Enhancements:
- Track last processed RA log file and line to prevent duplicate imports
- Merge imported RA lines into the round log in chronological order
- Use FileStream with ReadWrite sharing for log writing and track current log file path
- Automatically import RA logs on round end and restart
- Remove Warhead.Stopping event handler and associated method

</details>